### PR TITLE
SITES-28176 - Support product URLs with only urlKeys

### DIFF
--- a/actions/pdp-renderer/index.js
+++ b/actions/pdp-renderer/index.js
@@ -17,7 +17,7 @@ const { Core } = require('@adobe/aio-sdk')
 const Handlebars = require('handlebars');
 const { errorResponse, stringParameters, requestSaaS } = require('../utils');
 const { extractPathDetails, findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceString, getImageList } = require('./lib');
-const { ProductQuery } = require('../queries');
+const { ProductQuery, ProductByUrlKeyQuery } = require('../queries');
 const { generateLdJson } = require('./ldJson');
 
 function toTemplateProductData(baseProduct) {
@@ -44,36 +44,50 @@ function toTemplateProductData(baseProduct) {
  * @param {string} params.__ow_query.contentUrl Overwrite for HLX_CONTENT_URL
  * @param {string} params.__ow_query.storeUrl Overwrite for HLX_STORE_URL
  * @param {string} params.__ow_query.productsTemplate Overwrite for HLX_PRODUCTS_TEMPLATE
+ * @param {string} params.__ow_query.pathFormat Overwrite for HLX_PATH_FORMAT
  * @param {string} params.HLX_CONFIG_NAME The config sheet to use (e.g. configs for prod, configs-dev for dev)
  * @param {string} params.HLX_CONTENT_URL Edge Delivery URL of the store (e.g. aem.live)
  * @param {string} params.HLX_STORE_URL Public facing URL of the store
  * @param {string} params.HLX_PRODUCTS_TEMPLATE URL to the products template page
+ * @param {string} params.HLX_PATH_FORMAT The path format to use for parsing
  */
 async function main (params) {
   const logger = Core.Logger('main', { level: params.LOG_LEVEL || 'info' })
 
   try {
     logger.debug(stringParameters(params))
-    const { __ow_path, __ow_query, HLX_STORE_URL, HLX_CONTENT_URL, HLX_CONFIG_NAME, HLX_PRODUCTS_TEMPLATE } = params;
-    const { sku } = extractPathDetails(__ow_path);
+    const { __ow_path, __ow_query, HLX_STORE_URL, HLX_CONTENT_URL, HLX_CONFIG_NAME, HLX_PRODUCTS_TEMPLATE, HLX_PATH_FORMAT } = params;
 
+    const pathFormat = __ow_query?.pathFormat || HLX_PATH_FORMAT || '/products/{urlKey}/{sku}';
     const configName = __ow_query?.configName || HLX_CONFIG_NAME;
     const contentUrl = __ow_query?.contentUrl || HLX_CONTENT_URL;
     const storeUrl = __ow_query?.storeUrl || HLX_STORE_URL || contentUrl;
     const productsTemplate = __ow_query?.productsTemplate || HLX_PRODUCTS_TEMPLATE;
     const context = { contentUrl, storeUrl, configName, logger };
 
-    if (!sku || !contentUrl) {
+    const result = extractPathDetails(__ow_path, pathFormat);
+    logger.debug('Path parse results', JSON.stringify(result, null, 4));
+    const { sku, urlKey } = result;
+
+    if ((!sku && !urlKey) || !contentUrl) {
       return errorResponse(400, 'Invalid path', logger);
     }
 
     // Retrieve base product
-    const baseProductData = await requestSaaS(ProductQuery, 'ProductQuery', { sku }, context);
-    if (!baseProductData.data.products || baseProductData.data.products.length === 0) {
+    let baseProduct;
+    if (sku) {
+      const baseProductData = await requestSaaS(ProductQuery, 'ProductQuery', { sku: sku.toUpperCase() }, context);
+      if (!baseProductData?.data?.products || baseProductData?.data?.products?.length === 0) {
         return errorResponse(404, 'Product not found', logger);
+      }
+      baseProduct = baseProductData.data.products[0];
+    } else if (urlKey) {
+      const baseProductData = await requestSaaS(ProductByUrlKeyQuery, 'ProductByUrlKey', { urlKey }, context);
+      if (!baseProductData?.data?.productSearch || baseProductData?.data?.productSearch?.items?.length === 0) {
+        return errorResponse(404, 'Product not found', logger);
+      }
+      baseProduct = baseProductData.data.productSearch.items[0].productView;
     }
-    const baseProduct = baseProductData.data.products[0];
-
     logger.debug('Retrieved base product', JSON.stringify(baseProduct, null, 4));
 
     // Assign meta tag data for template

--- a/actions/pdp-renderer/index.js
+++ b/actions/pdp-renderer/index.js
@@ -39,12 +39,11 @@ function toTemplateProductData(baseProduct) {
  * Parameters
  * @param {Object} params The parameters object
  * @param {string} params.__ow_path The path of the request
- * @param {string} params.__ow_query The query parameters of the request
- * @param {string} params.__ow_query.configName Overwrite for HLX_CONFIG_NAME
- * @param {string} params.__ow_query.contentUrl Overwrite for HLX_CONTENT_URL
- * @param {string} params.__ow_query.storeUrl Overwrite for HLX_STORE_URL
- * @param {string} params.__ow_query.productsTemplate Overwrite for HLX_PRODUCTS_TEMPLATE
- * @param {string} params.__ow_query.pathFormat Overwrite for HLX_PATH_FORMAT
+ * @param {string} params.configName Overwrite for HLX_CONFIG_NAME using query parameter
+ * @param {string} params.contentUrl Overwrite for HLX_CONTENT_URL using query parameter
+ * @param {string} params.storeUrl Overwrite for HLX_STORE_URL using query parameter
+ * @param {string} params.productsTemplate Overwrite for HLX_PRODUCTS_TEMPLATE using query parameter
+ * @param {string} params.pathFormat Overwrite for HLX_PATH_FORMAT using query parameter
  * @param {string} params.HLX_CONFIG_NAME The config sheet to use (e.g. configs for prod, configs-dev for dev)
  * @param {string} params.HLX_CONTENT_URL Edge Delivery URL of the store (e.g. aem.live)
  * @param {string} params.HLX_STORE_URL Public facing URL of the store
@@ -56,14 +55,26 @@ async function main (params) {
 
   try {
     logger.debug(stringParameters(params))
-    const { __ow_path, __ow_query, HLX_STORE_URL, HLX_CONTENT_URL, HLX_CONFIG_NAME, HLX_PRODUCTS_TEMPLATE, HLX_PATH_FORMAT } = params;
+    const {
+      __ow_path,
+      pathFormat : pathFormatQuery,
+      configName : configNameQuery,
+      contentUrl : contentUrlQuery,
+      storeUrl : storeUrlQuery,
+      productsTemplate : productsTemplateQuery,
+      HLX_STORE_URL,
+      HLX_CONTENT_URL,
+      HLX_CONFIG_NAME,
+      HLX_PRODUCTS_TEMPLATE,
+      HLX_PATH_FORMAT
+    } = params;
 
-    const pathFormat = __ow_query?.pathFormat || HLX_PATH_FORMAT || '/products/{urlKey}/{sku}';
-    const configName = __ow_query?.configName || HLX_CONFIG_NAME;
-    const contentUrl = __ow_query?.contentUrl || HLX_CONTENT_URL;
-    const storeUrl = __ow_query?.storeUrl || HLX_STORE_URL || contentUrl;
-    const productsTemplate = __ow_query?.productsTemplate || HLX_PRODUCTS_TEMPLATE;
-    const context = { contentUrl, storeUrl, configName, logger };
+    const pathFormat = pathFormatQuery || HLX_PATH_FORMAT || '/products/{urlKey}/{sku}';
+    const configName = configNameQuery || HLX_CONFIG_NAME;
+    const contentUrl = contentUrlQuery || HLX_CONTENT_URL;
+    const storeUrl = storeUrlQuery || HLX_STORE_URL || contentUrl;
+    const productsTemplate = productsTemplateQuery || HLX_PRODUCTS_TEMPLATE;
+    const context = { contentUrl, storeUrl, configName, logger, pathFormat };
 
     const result = extractPathDetails(__ow_path, pathFormat);
     logger.debug('Path parse results', JSON.stringify(result, null, 4));

--- a/actions/pdp-renderer/index.js
+++ b/actions/pdp-renderer/index.js
@@ -15,7 +15,7 @@ const path = require('path');
 
 const { Core } = require('@adobe/aio-sdk')
 const Handlebars = require('handlebars');
-const { errorResponse, stringParameters, requestSaaS } = require('../utils');
+const { errorResponse, stringParameters, requestSaaS, mapLocale } = require('../utils');
 const { extractPathDetails, findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceString, getImageList } = require('./lib');
 const { ProductQuery, ProductByUrlKeyQuery } = require('../queries');
 const { generateLdJson } = require('./ldJson');
@@ -66,7 +66,8 @@ async function main (params) {
       HLX_CONTENT_URL,
       HLX_CONFIG_NAME,
       HLX_PRODUCTS_TEMPLATE,
-      HLX_PATH_FORMAT
+      HLX_PATH_FORMAT,
+      HLX_LOCALES,
     } = params;
 
     const pathFormat = pathFormatQuery || HLX_PATH_FORMAT || '/products/{urlKey}/{sku}';
@@ -74,14 +75,25 @@ async function main (params) {
     const contentUrl = contentUrlQuery || HLX_CONTENT_URL;
     const storeUrl = storeUrlQuery || HLX_STORE_URL || contentUrl;
     const productsTemplate = productsTemplateQuery || HLX_PRODUCTS_TEMPLATE;
-    const context = { contentUrl, storeUrl, configName, logger, pathFormat };
+    const allowedLocales = HLX_LOCALES ? HLX_LOCALES.split(',').map(a => a.trim()) : [];
+    let context = { contentUrl, storeUrl, configName, logger, pathFormat, allowedLocales };
 
     const result = extractPathDetails(__ow_path, pathFormat);
     logger.debug('Path parse results', JSON.stringify(result, null, 4));
-    const { sku, urlKey } = result;
+    const { sku, urlKey, locale } = result;
 
     if ((!sku && !urlKey) || !contentUrl) {
       return errorResponse(400, 'Invalid path', logger);
+    }
+
+    // Map locale to context
+    if (locale) {
+      try {
+      context = { ...context, ...mapLocale(locale, context) };
+      // eslint-disable-next-line no-unused-vars
+      } catch(e) {
+        return errorResponse(400, 'Invalid locale', logger);
+      }
     }
 
     // Retrieve base product

--- a/actions/pdp-renderer/ldJson.js
+++ b/actions/pdp-renderer/ldJson.js
@@ -1,5 +1,5 @@
-const { requestSaaS } = require('../utils');
-const { getProductUrl, findDescription, getPrimaryImage } = require('./lib');
+const { requestSaaS, getProductUrl } = require('../utils');
+const { findDescription, getPrimaryImage } = require('./lib');
 const { VariantsQuery } = require('../queries');
 
 function getOffer(product, url) {

--- a/actions/pdp-renderer/ldJson.js
+++ b/actions/pdp-renderer/ldJson.js
@@ -64,9 +64,9 @@ async function getVariants(baseProduct, url, axes, context) {
 }
 
 async function generateLdJson(product, context) {
-  const { name, sku, urlKey, __typename } = product;
+  const { name, sku, __typename } = product;
   const image = getPrimaryImage(product);
-  const url = getProductUrl(urlKey, sku, context);
+  const url = getProductUrl(product, context);
   const gtin = ''; // TODO: Add based on your data model (https://schema.org/gtin)
 
   let ldJson;

--- a/actions/pdp-renderer/lib.js
+++ b/actions/pdp-renderer/lib.js
@@ -2,30 +2,35 @@ const striptags = require('striptags');
 const cheerio = require('cheerio');
 
 /**
- * Extracts the SKU from the path.
+ * Extracts details from the path based on the provided format.
  * @param {string} path The path.
- * @returns {Object} An object containing the SKU.
+ * @param {string} format The format to extract details from the path.
+ * @returns {Object} An object containing the extracted details.
  * @throws Throws an error if the path is invalid.
  */
-function extractPathDetails(path) {
+function extractPathDetails(path, format) {
   if (!path) {
     return {};
   }
-  // TODO: Extend to support store code as well if configured
 
-  // Strip leading slash if present
-  if (path.startsWith('/')) {
-    path = path.substring(1);
+  const formatParts = format.split('/').filter(Boolean);
+  const pathParts = path.split('/').filter(Boolean);
+
+  if (formatParts.length !== pathParts.length) {
+    throw new Error(`Invalid path. Expected '${format}' format.`);
   }
 
-  const pathParts = path.split('/');
-  if (pathParts.length !== 3 || pathParts[0] !== 'products') {
-    throw new Error(`Invalid path. Expected '/products/{urlKey}/{sku}'`);
-  }
+  const result = {};
+  formatParts.forEach((part, index) => {
+    if (part.startsWith('{') && part.endsWith('}')) {
+      const key = part.substring(1, part.length - 1);
+      result[key] = pathParts[index];
+    } else if (part !== pathParts[index]) {
+      throw new Error(`Invalid path. Expected '${format}' format.`);
+    }
+  });
 
-  const sku = pathParts[2].toUpperCase();
-
-  return { sku };
+  return result;
 }
 
 /**

--- a/actions/pdp-renderer/lib.js
+++ b/actions/pdp-renderer/lib.js
@@ -36,14 +36,28 @@ function extractPathDetails(path, format) {
 /**
  * Constructs the URL of a product.
  *
- * @param {string} urlKey The url key of the product.
- * @param {string} sku The sku of the product.
- * @param {Object} context The context object containing the store URL.
- * @returns {string} The product url.
+ * @param {Object} product Product with sku and urlKey properties.
+ * @param {Object} context The context object containing the store URL and path format.
+ * @returns {string} The product url or null if storeUrl or pathFormat are missing.
  */
-function getProductUrl(urlKey, sku, context) {
-  const { storeUrl } = context;
-  return `${storeUrl}/products/${urlKey}/${sku}`;
+function getProductUrl(product, context) {
+  const { storeUrl, pathFormat } = context;
+  if (!storeUrl || !pathFormat) {
+    return null;
+  }
+
+  let path = pathFormat.split('/')
+    .filter(Boolean)
+    .map(part => {
+      if (part.startsWith('{') && part.endsWith('}')) {
+        const key = part.substring(1, part.length - 1);
+        return product[key];
+      }
+      return part;
+    });
+  path.unshift(storeUrl);
+
+  return path.join('/');
 }
 
 /**

--- a/actions/pdp-renderer/lib.js
+++ b/actions/pdp-renderer/lib.js
@@ -34,33 +34,6 @@ function extractPathDetails(path, format) {
 }
 
 /**
- * Constructs the URL of a product.
- *
- * @param {Object} product Product with sku and urlKey properties.
- * @param {Object} context The context object containing the store URL and path format.
- * @returns {string} The product url or null if storeUrl or pathFormat are missing.
- */
-function getProductUrl(product, context) {
-  const { storeUrl, pathFormat } = context;
-  if (!storeUrl || !pathFormat) {
-    return null;
-  }
-
-  let path = pathFormat.split('/')
-    .filter(Boolean)
-    .map(part => {
-      if (part.startsWith('{') && part.endsWith('}')) {
-        const key = part.substring(1, part.length - 1);
-        return product[key];
-      }
-      return part;
-    });
-  path.unshift(storeUrl);
-
-  return path.join('/');
-}
-
-/**
  * Finds the description of a product based on a priority list of fields.
  * @param {Object} product The product object.
  * @param {Array<string>} priority The list of fields to check for the description, in order of priority.
@@ -193,4 +166,4 @@ function getImageList(primary, images) {
   return imageList;
 }
 
-module.exports = { extractPathDetails, getProductUrl, findDescription, getPrimaryImage, prepareBaseTemplate, generatePriceString, getImageList };
+module.exports = { extractPathDetails, findDescription, getPrimaryImage, prepareBaseTemplate, generatePriceString, getImageList };

--- a/actions/queries.js
+++ b/actions/queries.js
@@ -1,139 +1,159 @@
-const ProductQuery = `query ProductQuery($sku: String!) {
-    products(skus: [$sku]) {
-      __typename
+const PriceFragment = `fragment priceFields on ProductViewPrice {
+  roles
+  regular {
+    amount {
+      currency
+      value
+    }
+  }
+  final {
+    amount {
+      currency
+      value
+    }
+  }
+}`;
+
+const ProductViewFragment = `fragment productViewFields on ProductView {
+  __typename
+  id
+  sku
+  name
+  url
+  description
+  shortDescription
+  metaDescription
+  metaKeyword
+  metaTitle
+  urlKey
+  inStock
+  externalId
+  lastModifiedAt
+  images(roles: []) {
+    url
+    label
+    roles
+  }
+  attributes(roles: ["visible_in_pdp"]) {
+    name
+    label
+    value
+    roles
+  }
+  ... on SimpleProductView {
+    price {
+      ...priceFields
+    }
+  }
+  ... on ComplexProductView {
+    options {
       id
-      sku
-      name
-      url
-      description
-      shortDescription
-      metaDescription
-      metaKeyword
-      metaTitle
-      urlKey
-      inStock
-      externalId
-      lastModifiedAt
-      images(roles: []) {
-        url
-        label
-        roles
-      }
-      attributes(roles: ["visible_in_pdp"]) {
-        name
-        label
-        value
-        roles
-      }
-      ... on SimpleProductView {
-        price {
-          ...priceFields
+      title
+      required
+      values {
+        id
+        title
+        inStock
+        ... on ProductViewOptionValueSwatch {
+          type
+          value
         }
       }
-      ... on ComplexProductView {
-        options {
-          id
-          title
-          required
-          values {
-            id
-            title
-            inStock
-            ... on ProductViewOptionValueSwatch {
-              type
-              value
-            }
-          }
-        }
-        priceRange {
-          maximum {
-            ...priceFields
-          }
-          minimum {
-            ...priceFields
-          }
-        }
+    }
+    priceRange {
+      maximum {
+        ...priceFields
+      }
+      minimum {
+        ...priceFields
       }
     }
   }
-  fragment priceFields on ProductViewPrice {
-    roles
-    regular {
-      amount {
-        currency
-        value
+}`;
+
+const ProductQuery = `query ProductQuery($sku: String!) {
+  products(skus: [$sku]) {
+    ...productViewFields
+  }
+}
+${ProductViewFragment}
+${PriceFragment}`;
+
+const ProductByUrlKeyQuery = `query ProductByUrlKey($urlKey: String!) {
+  productSearch(
+    current_page: 1
+    filter: [{ attribute: "url_key", eq: $urlKey }]
+    page_size: 1
+    phrase: ""
+  ) {
+    items {
+      productView {
+        ...productViewFields
       }
     }
-    final {
-      amount {
-        currency
-        value
-      }
-    }
-  }`;
+  }
+}
+${ProductViewFragment}
+${PriceFragment}`;
 
 const VariantsQuery = `query VariantsQuery($sku: String!) {
-    variants(sku: $sku) {
-      variants {
-        selections
-        product {
-          sku
+  variants(sku: $sku) {
+    variants {
+      selections
+      product {
+        sku
+        name
+        inStock
+        images(roles: []) {
+          url
+          roles
+        }
+        attributes(roles: ["visible_in_pdp"]) {
           name
-          inStock
-          images(roles: []) {
-            url
+          label
+          value
+          roles
+        }
+        ... on SimpleProductView {
+          price {
             roles
-          }
-          attributes(roles: ["visible_in_pdp"]) {
-            name
-            label
-            value
-            roles
-          }
-          ... on SimpleProductView {
-            price {
-              roles
-              regular {
-                amount {
-                  value
-                  currency
-                }
+            regular {
+              amount {
+                value
+                currency
               }
-              final {
-                amount {
-                  value
-                  currency
-                }
+            }
+            final {
+              amount {
+                value
+                currency
               }
             }
           }
         }
       }
     }
-  }`;
+  }
+}`;
 
-const GetAllSkusQuery = `
-  query getAllSkus {
-    productSearch(phrase: "", page_size: 500) {
-      items {
-        productView {
-          urlKey
-          sku
-        }
+const GetAllSkusQuery = `query getAllSkus {
+  productSearch(phrase: "", page_size: 500) {
+    items {
+      productView {
+        urlKey
+        sku
       }
     }
   }
-`;
+}`;
 
-const GetLastModifiedQuery = `
-  query getLastModified($skus: [String]!) {
-    products(skus: $skus) {
-      sku
-      urlKey
-      lastModifiedAt
-    }
+const GetLastModifiedQuery = `query getLastModified($skus: [String]!) {
+  products(skus: $skus) {
+    sku
+    urlKey
+    lastModifiedAt
   }
-`;
+}`;
 
 const GetAllSkusPaginatedQuery = `query getAllSkusPaginated($currentPage: Int!) {
 	productSearch(phrase: "", page_size: 500, current_page: $currentPage) {
@@ -144,11 +164,11 @@ const GetAllSkusPaginatedQuery = `query getAllSkusPaginated($currentPage: Int!) 
         }
     }
 	}
-}
-`;
+}`;
 
 module.exports = {
     ProductQuery,
+    ProductByUrlKeyQuery,
     VariantsQuery,
     GetAllSkusQuery,
     GetAllSkusPaginatedQuery,

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -4,18 +4,25 @@ application:
     packages:
       aem-commerce-ssg:
         license: Apache-2.0
+        inputs:
+          LOG_LEVEL: debug
+          HLX_CONTENT_URL: "https://main--aem-boilerplate-commerce--hlxsites.aem.live"
+          HLX_PRODUCTS_TEMPLATE: "https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/default"
+          HLX_ORG_NAME: "hlxsites"
+          HLX_SITE_NAME: "aem-boilerplate-commerce"
+          HLX_STORE_URL: "https://www.aemshop.net"
+          HLX_CONFIG_NAME: "configs"
+          HLX_PATH_FORMAT: "/products/{urlKey}/{sku}"
+          # HLX_LOCALES: comma-seprated list of allowed locales.
+          # i.e. us,uk,it,de,fr,es - or just one
+          # null if there is a single store and no
+          # URI prefixes are used
+          HLX_LOCALES: null
         actions:
           pdp-renderer:
             function: actions/pdp-renderer/index.js
             web: 'yes'
             runtime: nodejs:18
-            inputs:
-              LOG_LEVEL: debug
-              HLX_CONTENT_URL: "https://main--aem-boilerplate-commerce--hlxsites.aem.live"
-              HLX_PRODUCTS_TEMPLATE: "https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/default"
-              HLX_STORE_URL: "https://www.aemshop.net"
-              HLX_CONFIG_NAME: "configs"
-              HLX_PATH_FORMAT: "/products/{urlKey}/{sku}"
             annotations:
               final: true
             include:
@@ -28,19 +35,6 @@ application:
               memorySize: 128
               timeout: 3600000
             inputs:
-              LOG_LEVEL: debug
-              storeUrl: https://www.aemshop.net
-              orgName: hlxsites
-              siteName: aem-boilerplate-commerce
-              configName: configs
-              # storeCodes: comma-seprated list of store codes.
-              # i.e. us,uk,it,de,fr,es - or just one
-              # null if there is a single store and no
-              # URI prefixes are used
-              storeCodes: null
-              # PDPURIPrefix: URI prefix for the Product Pages
-              # i.e.: /products
-              PDPURIPrefix: /products
               authToken: ${AEM_ADMIN_API_AUTH_TOKEN}
             annotations:
               final: true

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -15,6 +15,7 @@ application:
               HLX_PRODUCTS_TEMPLATE: "https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/default"
               HLX_STORE_URL: "https://www.aemshop.net"
               HLX_CONFIG_NAME: "configs"
+              HLX_PATH_FORMAT: "/products/{urlKey}/{sku}"
             annotations:
               final: true
             include:

--- a/e2e/pdp-ssg.e2e.test.js
+++ b/e2e/pdp-ssg.e2e.test.js
@@ -21,7 +21,7 @@ const runtimePackage = 'aem-commerce-ssg'
 const actionUrl = `https://${namespace}.${hostname}/api/v1/web/${runtimePackage}/pdp-renderer`
 
 test('simple product markup', async () => {
-  const res = await fetch(`${actionUrl}/products/crown-summit-backpack/24-MB03`);
+  const res = await fetch(`${actionUrl}/products/crown-summit-backpack/24-mb03`);
   const content = await res.text();
 
   // Parse markup and compare
@@ -83,7 +83,7 @@ test('simple product markup', async () => {
 });
 
 test('complex product markup', async () => {
-  const res = await fetch(`${actionUrl}/products/hollister-backyard-sweatshirt/MH05`);
+  const res = await fetch(`${actionUrl}/products/hollister-backyard-sweatshirt/mh05`);
   const content = await res.text();
 
   // Parse markup and compare
@@ -456,3 +456,14 @@ test('complex product markup', async () => {
   };
   expect(ldJson).toEqual(expected);
 });
+
+test('product by urlKey', async () => {
+  const res = await fetch(`${actionUrl}/crown-summit-backpack?pathFormat=/{urlKey}`);
+  const content = await res.text();
+
+  // Parse markup and compare
+  const $ = cheerio.load(content);
+
+  // Validate H1
+  expect($('h1').text()).toEqual('Crown Summit Backpack');
+})

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -9,7 +9,7 @@ describe('Poller', () => {
     assert.deepEqual(
       state,
       {
-        storeCode: 'uk',
+        locale: 'uk',
         skus: {},
         skusLastQueriedAt: new Date(0),
       }
@@ -23,7 +23,7 @@ describe('Poller', () => {
     assert.deepEqual(
       state,
       {
-        storeCode: 'uk',
+        locale: 'uk',
         skus: {
           sku1: new Date(2),
           sku2: new Date(3),
@@ -50,7 +50,7 @@ describe('Poller', () => {
     assert.deepEqual(newState, state);
   });
 
-  it('loadState after saveState with null storeCode', async () => {
+  it('loadState after saveState with null locale', async () => {
     const stateLib = new State(0);
     await stateLib.put('default', '1,sku1,2,sku2,3,sku3,4');
     const state = await loadState(null, stateLib);

--- a/test/ldJson.test.js
+++ b/test/ldJson.test.js
@@ -17,7 +17,7 @@ const { useMockServer, handlers } = require('./mock-server.js');
 
 describe('ldJson', () => {
 
-    const mockContext = { contentUrl: 'https://content.com', storeUrl: 'https://example.com', configName: 'config', logger: { error: jest.fn() }, pathFormat: '/products/{urlKey}/{sku}' };
+    const mockContext = { contentUrl: 'https://content.com', storeUrl: 'https://example.com', configName: 'config', logger: { debug: jest.fn(), error: jest.fn() }, pathFormat: '/products/{urlKey}/{sku}' };
     const server = useMockServer();
 
     beforeEach(() => {

--- a/test/ldJson.test.js
+++ b/test/ldJson.test.js
@@ -17,7 +17,7 @@ const { useMockServer, handlers } = require('./mock-server.js');
 
 describe('ldJson', () => {
 
-    const mockContext = { contentUrl: 'https://content.com', storeUrl: 'https://example.com', configName: 'config', logger: { error: jest.fn() } };
+    const mockContext = { contentUrl: 'https://content.com', storeUrl: 'https://example.com', configName: 'config', logger: { error: jest.fn() }, pathFormat: '/products/{urlKey}/{sku}' };
     const server = useMockServer();
 
     beforeEach(() => {

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -42,13 +42,26 @@ describe('lib', () => {
         expect(getPrimaryImage({ images: [] })).toBeUndefined();
     });
 
-    test('extractPathDetails', () => {
-        expect(extractPathDetails('/products/urlKey/sku')).toEqual({ sku: 'SKU' });
-        expect(extractPathDetails('products/urlKey/sku')).toEqual({ sku: 'SKU' });
-        expect(() => extractPathDetails('/products/urlKey/sku/extra')).toThrow(`Invalid path. Expected '/products/{urlKey}/{sku}'`);
-        expect(() => extractPathDetails('/product/urlKey/sku')).toThrow(`Invalid path. Expected '/products/{urlKey}/{sku}'`);
-        expect(extractPathDetails('')).toEqual({});
-        expect(extractPathDetails(null)).toEqual({});
+
+    describe('extractPathDetails', () => {
+        test('extract sku and urlKey from path', () => {
+            expect(extractPathDetails('/products/my-url-key/my-sku', '/products/{urlKey}/{sku}')).toEqual({ sku: 'my-sku', urlKey: 'my-url-key' });
+        });
+        test('extract urlKey from path', () => {
+            expect(extractPathDetails('/my-url-key', '/{urlKey}')).toEqual({ urlKey: 'my-url-key' });
+        });
+        test('throw error if path is too long', () => {
+            expect(() => extractPathDetails('/products/my-url-key/my-sku', '/products/{urlKey}')).toThrow(`Invalid path. Expected '/products/{urlKey}' format.`);
+        });
+        test('throw error if static part of path does not match', () => {
+            expect(() => extractPathDetails('/product/my-sku', '/products/{sku}')).toThrow(`Invalid path. Expected '/products/{sku}' format.`);
+        });
+        test('empty object for empty path', () => {
+            expect(extractPathDetails('')).toEqual({});
+        });
+        test('empty object for null path', () => {
+            expect(extractPathDetails(null)).toEqual({});
+        });
     });
 
     test('getProductUrl', () => {

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { findDescription, getPrimaryImage, extractPathDetails, getProductUrl, generatePriceString } = require('../actions/pdp-renderer/lib');
+const { findDescription, getPrimaryImage, extractPathDetails, generatePriceString } = require('../actions/pdp-renderer/lib');
 
 describe('lib', () => {
     test('findDescription', () => {
@@ -61,28 +61,6 @@ describe('lib', () => {
         });
         test('empty object for null path', () => {
             expect(extractPathDetails(null)).toEqual({});
-        });
-    });
-
-    describe('getProductUrl', () => {
-        test('getProductUrl with urlKey and sku', () => {
-            const context = { storeUrl: 'https://example.com', pathFormat: '/products/{urlKey}/{sku}' };
-            expect(getProductUrl({ urlKey: 'my-url-key', sku: 'my-sku' }, context)).toBe('https://example.com/products/my-url-key/my-sku');
-        });
-
-        test('getProductUrl with urlKey', () => {
-            const context = { storeUrl: 'https://example.com', pathFormat: '/{urlKey}' };
-            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe('https://example.com/my-url-key');
-        });
-
-        test('return null for missing storeUrl', () => {
-            const context = { pathFormat: '/{urlKey}' };
-            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe(null);
-        });
-
-        test('return null for missing pathFormat', () => {
-            const context = { storeUrl: 'https://example.com' };
-            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe(null);
         });
     });
 

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -64,9 +64,26 @@ describe('lib', () => {
         });
     });
 
-    test('getProductUrl', () => {
-        const context = { storeUrl: 'https://example.com' };
-        expect(getProductUrl('urlKey', 'sku', context)).toBe('https://example.com/products/urlKey/sku');
+    describe('getProductUrl', () => {
+        test('getProductUrl with urlKey and sku', () => {
+            const context = { storeUrl: 'https://example.com', pathFormat: '/products/{urlKey}/{sku}' };
+            expect(getProductUrl({ urlKey: 'my-url-key', sku: 'my-sku' }, context)).toBe('https://example.com/products/my-url-key/my-sku');
+        });
+
+        test('getProductUrl with urlKey', () => {
+            const context = { storeUrl: 'https://example.com', pathFormat: '/{urlKey}' };
+            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe('https://example.com/my-url-key');
+        });
+
+        test('return null for missing storeUrl', () => {
+            const context = { pathFormat: '/{urlKey}' };
+            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe(null);
+        });
+
+        test('return null for missing pathFormat', () => {
+            const context = { storeUrl: 'https://example.com' };
+            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe(null);
+        });
     });
 
     test('generatePriceString', () => {

--- a/test/mock-responses/mock-product-ls.json
+++ b/test/mock-responses/mock-product-ls.json
@@ -1,0 +1,187 @@
+{
+    "data": {
+        "productSearch": {
+            "items": [
+                {
+                    "productView": {
+                        "__typename": "SimpleProductView",
+                        "id": "TWpRdFRVSXdNdwBaR1ZtWVhWc2RBAFpqTTRZVEJrWlRBdE56WTBZaTAwTVdaaExXSmtNbU10TldKak1tWXpZemRpTXpsaABiV0ZwYmw5M1pXSnphWFJsWDNOMGIzSmwAWW1GelpRAFRVRkhNREExTXpZeE56STU",
+                        "sku": "24-MB03",
+                        "name": "Crown Summit Backpack",
+                        "url": "http://www.aemshop.net/crown-summit-backpack.html",
+                        "description": "<p>The Crown Summit Backpack is equally at home in a gym locker, study cube or a pup tent, so be sure yours is packed with books, a bag lunch, water bottles, yoga block, laptop, or whatever else you want in hand. Rugged enough for day hikes and camping trips, it has two large zippered compartments and padded, adjustable shoulder straps.</p>\r\n<ul>\r\n<li>Top handle.</li>\r\n<li>Grommet holes.</li>\r\n<li>Two-way zippers.</li>\r\n<li>H 20\" x W 14\" x D 12\".</li>\r\n<li>Weight: 2 lbs, 8 oz. Volume: 29 L.</li>\r\n<ul>",
+                        "shortDescription": "",
+                        "metaDescription": "",
+                        "metaKeyword": "",
+                        "metaTitle": "",
+                        "urlKey": "crown-summit-backpack",
+                        "inStock": true,
+                        "externalId": "7",
+                        "lastModifiedAt": "2024-10-03T15:26:48.850Z",
+                        "images": [
+                            {
+                                "url": "http://www.aemshop.net/media/catalog/product/m/b/mb03-black-0.jpg",
+                                "label": "Image",
+                                "roles": [
+                                    "image",
+                                    "small_image",
+                                    "thumbnail"
+                                ]
+                            },
+                            {
+                                "url": "http://www.aemshop.net/media/catalog/product/m/b/mb03-black-0_alt1.jpg",
+                                "label": "Image",
+                                "roles": []
+                            }
+                        ],
+                        "attributes": [
+                            {
+                                "name": "activity",
+                                "label": "Activity",
+                                "value": [
+                                    "Gym",
+                                    "Hiking",
+                                    "Overnight",
+                                    "School",
+                                    "Trail",
+                                    "Travel",
+                                    "Urban"
+                                ],
+                                "roles": [
+                                    "visible_in_pdp",
+                                    "visible_in_compare_list",
+                                    "visible_in_search"
+                                ]
+                            },
+                            {
+                                "name": "color",
+                                "label": "Color",
+                                "value": "",
+                                "roles": [
+                                    "visible_in_pdp",
+                                    "visible_in_compare_list",
+                                    "visible_in_plp",
+                                    "visible_in_search"
+                                ]
+                            },
+                            {
+                                "name": "cost",
+                                "label": "Cost",
+                                "value": "",
+                                "roles": [
+                                    "visible_in_pdp"
+                                ]
+                            },
+                            {
+                                "name": "eco_collection",
+                                "label": "Eco Collection",
+                                "value": "no",
+                                "roles": [
+                                    "visible_in_pdp"
+                                ]
+                            },
+                            {
+                                "name": "erin_recommends",
+                                "label": "Erin Recommends",
+                                "value": "no",
+                                "roles": [
+                                    "visible_in_pdp"
+                                ]
+                            },
+                            {
+                                "name": "features_bags",
+                                "label": "Features",
+                                "value": [
+                                    "Audio Pocket",
+                                    "Waterproof",
+                                    "Lightweight",
+                                    "Reflective",
+                                    "Laptop Sleeve"
+                                ],
+                                "roles": [
+                                    "visible_in_pdp",
+                                    "visible_in_search"
+                                ]
+                            },
+                            {
+                                "name": "material",
+                                "label": "Material",
+                                "value": [
+                                    "Nylon",
+                                    "Polyester"
+                                ],
+                                "roles": [
+                                    "visible_in_pdp",
+                                    "visible_in_search"
+                                ]
+                            },
+                            {
+                                "name": "new",
+                                "label": "New",
+                                "value": "no",
+                                "roles": [
+                                    "visible_in_pdp"
+                                ]
+                            },
+                            {
+                                "name": "performance_fabric",
+                                "label": "Performance Fabric",
+                                "value": "no",
+                                "roles": [
+                                    "visible_in_pdp"
+                                ]
+                            },
+                            {
+                                "name": "sale",
+                                "label": "Sale",
+                                "value": "no",
+                                "roles": [
+                                    "visible_in_pdp"
+                                ]
+                            },
+                            {
+                                "name": "strap_bags",
+                                "label": "Strap/Handle",
+                                "value": [
+                                    "Adjustable",
+                                    "Double",
+                                    "Padded"
+                                ],
+                                "roles": [
+                                    "visible_in_pdp",
+                                    "visible_in_search"
+                                ]
+                            },
+                            {
+                                "name": "style_bags",
+                                "label": "Style",
+                                "value": "Backpack",
+                                "roles": [
+                                    "visible_in_pdp",
+                                    "visible_in_search"
+                                ]
+                            }
+                        ],
+                        "price": {
+                            "roles": [
+                                "visible"
+                            ],
+                            "regular": {
+                                "amount": {
+                                    "currency": "USD",
+                                    "value": 38
+                                }
+                            },
+                            "final": {
+                                "amount": {
+                                    "currency": "USD",
+                                    "value": 38
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/test/mock-server.js
+++ b/test/mock-server.js
@@ -17,6 +17,7 @@ const path = require('path');
 const mockConfig = require('./mock-responses/mock-config.json');
 const mockVariants = require('./mock-responses/mock-variants.json');
 const mockProduct = require('./mock-responses/mock-product.json');
+const mockProductLs = require('./mock-responses/mock-product-ls.json');
 const mockComplexProduct = require('./mock-responses/mock-complex-product.json');
 const mockProductTemplate = fs.readFileSync(path.resolve(__dirname, './mock-responses/product-default.html'), 'utf8');
 
@@ -32,6 +33,10 @@ const handlers = {
   defaultVariant: (matcher) => graphql.query('VariantsQuery', (req) => {
     matcher?.(req);
     return HttpResponse.json(mockVariants);
+  }),
+  defaultProductLiveSearch: (matcher) => graphql.query('ProductByUrlKey', (req) => {
+    matcher?.(req);
+    return HttpResponse.json(mockProductLs);
   }),
   return404: (matcher) => graphql.query('ProductQuery', (req) => {
     matcher?.(req);

--- a/test/pdp-renderer.test.js
+++ b/test/pdp-renderer.test.js
@@ -97,6 +97,48 @@ describe('pdp-renderer', () => {
     expect($('body > main > div')).toHaveLength(1);
   });
 
+  test('get product by sku', async () => {
+    server.use(handlers.defaultProduct());
+
+    const response = await action.main({
+      HLX_STORE_URL: 'https://store.com',
+      HLX_CONTENT_URL: 'https://content.com',
+      HLX_CONFIG_NAME: 'config',
+      HLX_PATH_FORMAT: '/products/{sku}',
+      __ow_path: `/products/24-MB03`,
+    });
+
+    const $ = cheerio.load(response.body);
+    expect($('body > main > div.product-details > div > div > h1').text()).toEqual('Crown Summit Backpack');
+  });
+
+  test('get product by urlKey', async () => {
+    server.use(handlers.defaultProductLiveSearch());
+
+    const response = await action.main({
+      HLX_STORE_URL: 'https://store.com',
+      HLX_CONTENT_URL: 'https://content.com',
+      HLX_CONFIG_NAME: 'config',
+      HLX_PATH_FORMAT: '/{urlKey}',
+      __ow_path: `/crown-summit-backpack`,
+    });
+   
+    const $ = cheerio.load(response.body);
+    expect($('body > main > div.product-details > div > div > h1').text()).toEqual('Crown Summit Backpack');
+  });
+
+  test('return 400 if neither sku nor urlKey are provided', async () => {
+    const response = await action.main({
+      HLX_STORE_URL: 'https://store.com',
+      HLX_CONTENT_URL: 'https://content.com',
+      HLX_CONFIG_NAME: 'config',
+      HLX_PATH_FORMAT: '/{urlPath}',
+      __ow_path: `/crown-summit-backpack`,
+    });
+
+    expect(response.error.statusCode).toEqual(400);
+  });
+
   test('render images', async () => {
     server.use(handlers.defaultProduct());
 

--- a/test/pdp-renderer.test.js
+++ b/test/pdp-renderer.test.js
@@ -11,6 +11,8 @@ governing permissions and limitations under the License.
 */
 
 const cheerio = require('cheerio');
+const { http, HttpResponse } = require('msw');
+
 const { useMockServer, handlers } = require('./mock-server.js');
 
 jest.mock('@adobe/aio-sdk', () => ({
@@ -125,6 +127,47 @@ describe('pdp-renderer', () => {
    
     const $ = cheerio.load(response.body);
     expect($('body > main > div.product-details > div > div > h1').text()).toEqual('Crown Summit Backpack');
+  });
+
+  test('render product with locale', async () => {
+    server.use(handlers.defaultProduct());
+
+    let configRequestUrl;
+    const mockConfig = require('./mock-responses/mock-config.json');
+    server.use(http.get('https://content.com/en/config.json', async (req) => {
+      configRequestUrl = req.request.url;
+      return HttpResponse.json(mockConfig);
+    }));
+
+    const response = await action.main({
+      HLX_STORE_URL: 'https://store.com',
+      HLX_CONTENT_URL: 'https://content.com',
+      HLX_CONFIG_NAME: 'config',
+      HLX_PATH_FORMAT: '/{locale}/products/{sku}',
+      __ow_path: `/en/products/24-MB03`,
+    });
+
+    expect(configRequestUrl).toBe('https://content.com/en/config.json');
+
+    // Validate product
+    const $ = cheerio.load(response.body);
+    expect($('body > main > div.product-details > div > div > h1').text()).toEqual('Crown Summit Backpack');
+
+    // Validate product url in structured data
+    const ldJson = JSON.parse($('head > script[type="application/ld+json"]').html());
+    expect(ldJson.offers[0].url).toEqual('https://store.com/en/products/24-MB03');
+  });
+
+  test('return 400 if locale is not supported', async () => {
+    const response = await action.main({
+      HLX_STORE_URL: 'https://store.com',
+      HLX_CONTENT_URL: 'https://content.com',
+      HLX_CONFIG_NAME: 'config',
+      HLX_PATH_FORMAT: '/{locale}/products/{sku}',
+      __ow_path: `/test/products/24-MB03`,
+    });
+
+    expect(response.error.statusCode).toEqual(400);
   });
 
   test('return 400 if neither sku nor urlKey are provided', async () => {


### PR DESCRIPTION
* Introduced new `HLX_PATH_FORMAT` parameter which allows to set the accepted URL structure for PDPs.
    * Example: `/products/{urlKey}/{sku}` for PDPs like `aemshop.net/products/crown-summit-backpack/24-mb03`
    * Example: `/{urlKey}` for PDPs like `aemshop.net/crown-summit-backpack`
* The renderer requires to have either `sku` or `urlKey` properties be present in the URL. Lookup by SKU is done by querying Catalog Service while lookup by urlKey is done by querying LiveSearch.
* Changed the way how query parameters are handled to overwrite configuration values. (See [discussion](https://cq-dev.slack.com/archives/C013UDBFBGB/p1659719214120209)).
    * AppBuilder provides the `__ow_query` parameter only for `raw` web actions. Otherwise query parameters are parsed and passed as part of the `params` object. Additionally, query parameters cannot overwrite values from `app.config.yaml`, that's why I changed the naming.
* Added additional tests.

Includes #19 