### PR TITLE
SITES-28179 - Add support for locale URLs

### DIFF
--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -12,18 +12,18 @@ governing permissions and limitations under the License.
 
 const { Timings, aggregate } = require('./lib/benchmark');
 const { AdminAPI } = require('./lib/aem');
-const { requestSaaS, requestSpreadsheet, isValidUrl } = require('../utils');
+const { requestSaaS, requestSpreadsheet, isValidUrl, getProductUrl, mapLocale } = require('../utils');
 const { GetAllSkusQuery, GetLastModifiedQuery } = require('../queries');
 const { Core } = require('@adobe/aio-sdk');
 
 const BATCH_SIZE = 50;
 
-async function loadState(storeCode, stateLib) {
-  const stateKey = storeCode ? `${storeCode}` : 'default';
+async function loadState(locale, stateLib) {
+  const stateKey = locale ? `${locale}` : 'default';
   const stateData = await stateLib.get(stateKey);
   if (!stateData?.value) {
     return {
-      storeCode,
+      locale,
       skusLastQueriedAt: new Date(0),
       skus: {},
     };
@@ -34,7 +34,7 @@ async function loadState(storeCode, stateLib) {
   // folloed by a pair of SKUs and timestamps which are the last preview times per SKU
   const [catalogQueryTimestamp, ...skus] = stateData && stateData.value ? stateData.value.split(',') : [0];
   return {
-    storeCode,
+    locale,
     skusLastQueriedAt: new Date(parseInt(catalogQueryTimestamp)),
     skus: Object.fromEntries(skus
       .map((sku, i, arr) => (i % 2 === 0 ? [sku, new Date(parseInt(arr[i + 1]))] : null))
@@ -43,11 +43,11 @@ async function loadState(storeCode, stateLib) {
 }
 
 async function saveState(state, stateLib) {
-  let { storeCode } = state;
-  if (!storeCode) {
-    storeCode = 'default';
+  let { locale } = state;
+  if (!locale) {
+    locale = 'default';
   }
-  const stateKey = `${storeCode}`;
+  const stateKey = `${locale}`;
   const stateData = [
     state.skusLastQueriedAt.getTime(),
     ...Object.entries(state.skus).flatMap(([sku, lastPreviewedAt]) => [sku, lastPreviewedAt.getTime()]),
@@ -61,28 +61,28 @@ async function saveState(state, stateLib) {
  * state accordingly.
  *
  * @param {Object} params - The parameters object.
- * @param {string} params.siteName - The name of the site (repo or repoless).
- * @param {string} params.PDPURIPrefix - The URI prefix for Product Detail Pages.
+ * @param {string} params.HLX_SITE_NAME - The name of the site (repo or repoless).
+ * @param {string} params.HLX_PATH_FORMAT - The URL format for product detail pages.
  * @param {string} params.PLPURIPrefix - The URI prefix for Product List Pages.
- * @param {string} params.orgName - The name of the organization.
- * @param {string} params.configName - The name of the configuration json/xlsx.
+ * @param {string} params.HLX_ORG_NAME - The name of the organization.
+ * @param {string} params.HLX_CONFIG_NAME - The name of the configuration json/xlsx.
  * @param {number} [params.requestPerSecond=5] - The number of requests per second allowed by the throttling logic.
  * @param {string} params.authToken - The authentication token.
  * @param {number} [params.skusRefreshInterval=600000] - The interval for refreshing SKUs in milliseconds.
- * @param {string} [params.storeUrl] - The store's base URL.
- * @param {string} [params.storeCodes] - Comma-separated list of store codes.
+ * @param {string} [params.HLX_STORE_URL] - The store's base URL.
+ * @param {string} [params.HLX_LOCALES] - Comma-separated list of allowed locales.
  * @param {string} [params.LOG_LEVEL] - The log level.
  * @param {Object} stateLib - The state provider object.
  * @returns {Promise<Object>} The result of the polling action.
  */
 function checkParams(params) {
-  const requiredParams = ['siteName', 'PDPURIPrefix', 'PLPURIPrefix', 'orgName', 'configName', 'authToken'];
+  const requiredParams = ['HLX_SITE_NAME', 'HLX_PATH_FORMAT', 'PLPURIPrefix', 'HLX_ORG_NAME', 'HLX_CONFIG_NAME', 'authToken'];
   const missingParams = requiredParams.filter(param => !params[param]);
   if (missingParams.length > 0) {
     throw new Error(`Missing required parameters: ${missingParams.join(', ')}`);
   }
 
-  if (params.storeUrl && !isValidUrl(params.storeUrl)) {
+  if (params.HLX_STORE_URL && !isValidUrl(params.HLX_STORE_URL)) {
     throw new Error('Invalid storeUrl');
   }
 }
@@ -112,22 +112,22 @@ async function poll(params, stateLib) {
 
   const log = Core.Logger('main', { level: params.LOG_LEVEL || 'info' });
   const {
-    siteName,
-    PDPURIPrefix,
-    orgName,
-    configName,
+    HLX_SITE_NAME: siteName,
+    HLX_PATH_FORMAT: pathFormat,
+    HLX_ORG_NAME: orgName,
+    HLX_CONFIG_NAME: configName,
     requestPerSecond = 5,
     authToken,
     skusRefreshInterval = 600000,
   } = params;
-  const storeUrl = params.storeUrl ? params.storeUrl : `https://main--${siteName}--${orgName}.aem.live`;
-  const storeCodes = params.storeCodes ? params.storeCodes.split(',') : [null];
+  const storeUrl = params.HLX_STORE_URL ? params.HLX_STORE_URL : `https://main--${siteName}--${orgName}.aem.live`;
+  const locales = params.HLX_LOCALES ? params.HLX_LOCALES.split(',') : [null];
 
   const counts = {
     published: 0, unpublished: 0, ignored: 0, failed: 0,
   };
   const sharedContext = {
-    storeUrl, configName, log, counts,
+    storeUrl, configName, log, counts, pathFormat,
   };
   const timings = new Timings();
   const adminApi = new AdminAPI({
@@ -135,18 +135,22 @@ async function poll(params, stateLib) {
     site: siteName,
   }, sharedContext, { requestPerSecond, authToken });
 
-  log.info(`Starting poll from ${storeUrl} for store codes ${storeCodes}`);
+  log.info(`Starting poll from ${storeUrl} for locales ${locales}`);
 
   try {
     // start processing preview and publish queues
     await adminApi.startProcessing();
 
-    const results = await Promise.all(storeCodes.map(async (storeCode) => {
+    const results = await Promise.all(locales.map(async (locale) => {
       const timings = new Timings();
       // load state
-      const state = await loadState(storeCode, stateLib);
+      const state = await loadState(locale, stateLib);
       timings.sample('loadedState');
-      const context = { ...sharedContext, storeCode };
+
+      let context = { ...sharedContext };
+      if (locale) {
+        context = { ...context, ...mapLocale(locale, context) };
+      }
 
       // setup preview / publish queues
 
@@ -198,7 +202,7 @@ async function poll(params, stateLib) {
       const batches = products.filter(shouldProcessProduct)
         .reduce((acc, product, i, arr) => {
           const { sku, urlKey } = product;
-          const path = (storeCode ? `/${storeCode}${PDPURIPrefix}/${urlKey}/${sku}` : `${PDPURIPrefix}/${urlKey}/${sku}`).toLowerCase();
+          const path = getProductUrl({ urlKey, sku }, context).toLowerCase();
           const req = adminApi.previewAndPublish({ path, sku });
           acc.push(req);
           if (acc.length === BATCH_SIZE || i === arr.length - 1) {

--- a/actions/pdp-renderer/index.js
+++ b/actions/pdp-renderer/index.js
@@ -15,8 +15,8 @@ const path = require('path');
 
 const { Core } = require('@adobe/aio-sdk')
 const Handlebars = require('handlebars');
-const { errorResponse, stringParameters, requestSaaS } = require('../utils');
-const { extractPathDetails, findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceString, getImageList, mapLocale } = require('./lib');
+const { errorResponse, stringParameters, requestSaaS, mapLocale } = require('../utils');
+const { extractPathDetails, findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceString, getImageList } = require('./lib');
 const { ProductQuery, ProductByUrlKeyQuery } = require('../queries');
 const { generateLdJson } = require('./ldJson');
 

--- a/actions/pdp-renderer/index.js
+++ b/actions/pdp-renderer/index.js
@@ -66,7 +66,8 @@ async function main (params) {
       HLX_CONTENT_URL,
       HLX_CONFIG_NAME,
       HLX_PRODUCTS_TEMPLATE,
-      HLX_PATH_FORMAT
+      HLX_PATH_FORMAT,
+      HLX_LOCALES,
     } = params;
 
     const pathFormat = pathFormatQuery || HLX_PATH_FORMAT || '/products/{urlKey}/{sku}';
@@ -74,7 +75,8 @@ async function main (params) {
     const contentUrl = contentUrlQuery || HLX_CONTENT_URL;
     const storeUrl = storeUrlQuery || HLX_STORE_URL || contentUrl;
     const productsTemplate = productsTemplateQuery || HLX_PRODUCTS_TEMPLATE;
-    let context = { contentUrl, storeUrl, configName, logger, pathFormat };
+    const allowedLocales = HLX_LOCALES ? HLX_LOCALES.split(',').map(a => a.trim()) : [];
+    let context = { contentUrl, storeUrl, configName, logger, pathFormat, allowedLocales };
 
     const result = extractPathDetails(__ow_path, pathFormat);
     logger.debug('Path parse results', JSON.stringify(result, null, 4));

--- a/actions/pdp-renderer/index.js
+++ b/actions/pdp-renderer/index.js
@@ -88,7 +88,12 @@ async function main (params) {
 
     // Map locale to context
     if (locale) {
+      try {
       context = { ...context, ...mapLocale(locale, context) };
+      // eslint-disable-next-line no-unused-vars
+      } catch(e) {
+        return errorResponse(400, 'Invalid locale', logger);
+      }
     }
 
     // Retrieve base product

--- a/actions/pdp-renderer/index.js
+++ b/actions/pdp-renderer/index.js
@@ -16,7 +16,7 @@ const path = require('path');
 const { Core } = require('@adobe/aio-sdk')
 const Handlebars = require('handlebars');
 const { errorResponse, stringParameters, requestSaaS } = require('../utils');
-const { extractPathDetails, findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceString, getImageList } = require('./lib');
+const { extractPathDetails, findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceString, getImageList, mapLocale } = require('./lib');
 const { ProductQuery, ProductByUrlKeyQuery } = require('../queries');
 const { generateLdJson } = require('./ldJson');
 
@@ -74,14 +74,19 @@ async function main (params) {
     const contentUrl = contentUrlQuery || HLX_CONTENT_URL;
     const storeUrl = storeUrlQuery || HLX_STORE_URL || contentUrl;
     const productsTemplate = productsTemplateQuery || HLX_PRODUCTS_TEMPLATE;
-    const context = { contentUrl, storeUrl, configName, logger, pathFormat };
+    let context = { contentUrl, storeUrl, configName, logger, pathFormat };
 
     const result = extractPathDetails(__ow_path, pathFormat);
     logger.debug('Path parse results', JSON.stringify(result, null, 4));
-    const { sku, urlKey } = result;
+    const { sku, urlKey, locale } = result;
 
     if ((!sku && !urlKey) || !contentUrl) {
       return errorResponse(400, 'Invalid path', logger);
+    }
+
+    // Map locale to context
+    if (locale) {
+      context = { ...context, ...mapLocale(locale, context) };
     }
 
     // Retrieve base product

--- a/actions/pdp-renderer/ldJson.js
+++ b/actions/pdp-renderer/ldJson.js
@@ -1,5 +1,5 @@
-const { requestSaaS } = require('../utils');
-const { getProductUrl, findDescription, getPrimaryImage } = require('./lib');
+const { requestSaaS, getProductUrl } = require('../utils');
+const { findDescription, getPrimaryImage } = require('./lib');
 const { VariantsQuery } = require('../queries');
 
 function getOffer(product, url) {

--- a/actions/pdp-renderer/lib.js
+++ b/actions/pdp-renderer/lib.js
@@ -34,39 +34,6 @@ function extractPathDetails(path, format) {
 }
 
 /**
- * Constructs the URL of a product.
- *
- * @param {Object} product Product with sku and urlKey properties.
- * @param {Object} context The context object containing the store URL and path format.
- * @returns {string} The product url or null if storeUrl or pathFormat are missing.
- */
-function getProductUrl(product, context) {
-  const { storeUrl, pathFormat } = context;
-  if (!storeUrl || !pathFormat) {
-    return null;
-  }
-
-  const availableParams = {
-    sku: product.sku,
-    urlKey: product.urlKey,
-    locale: context.locale,
-  };
-
-  let path = pathFormat.split('/')
-    .filter(Boolean)
-    .map(part => {
-      if (part.startsWith('{') && part.endsWith('}')) {
-        const key = part.substring(1, part.length - 1);
-        return availableParams[key];
-      }
-      return part;
-    });
-  path.unshift(storeUrl);
-
-  return path.join('/');
-}
-
-/**
  * Finds the description of a product based on a priority list of fields.
  * @param {Object} product The product object.
  * @param {Array<string>} priority The list of fields to check for the description, in order of priority.
@@ -199,26 +166,4 @@ function getImageList(primary, images) {
   return imageList;
 }
 
-/**
- * Adjust the context according to the given locale.
- * 
- * TODO: Customize this function to match your multi store setup
- * 
- * @param {string} locale The locale to map.
- * @returns {Object} An object containing the adjusted context.
- */
-function mapLocale(locale, context) {
-  // List of allowed locales
-  const allowedLocales = ['en', 'fr'];
-  if (!locale || !allowedLocales.includes(locale)) {
-    locale = 'en';
-  }
-
-  // Example for dedicated config file per locale
-  return {
-    locale,
-    configName: [locale, context.configName].join('/'),
-  }
-}
-
-module.exports = { extractPathDetails, getProductUrl, findDescription, getPrimaryImage, prepareBaseTemplate, generatePriceString, getImageList, mapLocale };
+module.exports = { extractPathDetails, findDescription, getPrimaryImage, prepareBaseTemplate, generatePriceString, getImageList };

--- a/actions/pdp-renderer/lib.js
+++ b/actions/pdp-renderer/lib.js
@@ -46,12 +46,18 @@ function getProductUrl(product, context) {
     return null;
   }
 
+  const availableParams = {
+    sku: product.sku,
+    urlKey: product.urlKey,
+    locale: context.locale,
+  };
+
   let path = pathFormat.split('/')
     .filter(Boolean)
     .map(part => {
       if (part.startsWith('{') && part.endsWith('}')) {
         const key = part.substring(1, part.length - 1);
-        return product[key];
+        return availableParams[key];
       }
       return part;
     });
@@ -193,4 +199,26 @@ function getImageList(primary, images) {
   return imageList;
 }
 
-module.exports = { extractPathDetails, getProductUrl, findDescription, getPrimaryImage, prepareBaseTemplate, generatePriceString, getImageList };
+/**
+ * Adjust the context according to the given locale.
+ * 
+ * TODO: Customize this function to match your multi store setup
+ * 
+ * @param {string} locale The locale to map.
+ * @returns {Object} An object containing the adjusted context.
+ */
+function mapLocale(locale, context) {
+  // List of allowed locales
+  const allowedLocales = ['en', 'fr'];
+  if (!locale || !allowedLocales.includes(locale)) {
+    locale = 'en';
+  }
+
+  // Example for dedicated config file per locale
+  return {
+    locale,
+    configName: [locale, context.configName].join('/'),
+  }
+}
+
+module.exports = { extractPathDetails, getProductUrl, findDescription, getPrimaryImage, prepareBaseTemplate, generatePriceString, getImageList, mapLocale };

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -112,7 +112,7 @@ function getBearerToken (params) {
 
 /**
  *
- * Returns an error response object and attempts to log.info the status code and error message
+ * Returns an error response object and attempts to logger.info the status code and error message
  *
  * @param {number} statusCode the error status code.
  *        e.g. 400

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -331,10 +331,10 @@ function getProductUrl(product, context, addStore = true) {
  * @returns {Object} An object containing the adjusted context.
  */
 function mapLocale(locale, context) {
-  // List of allowed locales
+  // Check if locale is valid
   const allowedLocales = ['en', 'fr']; // Or use context.allowedLocales derived from HLX_LOCALES configuration
   if (!locale || !allowedLocales.includes(locale)) {
-    locale = 'en';
+    throw new Error('Invalid locale');
   }
 
   // Example for dedicated config file per locale

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -191,12 +191,8 @@ async function request(name, url, req, timeout = 60000) {
  * @returns {Promise<object>} spreadsheet data as JSON.
  */
 async function requestSpreadsheet(name, sheet, context) {
-  const { contentUrl, storeCode } = context;
-  let storeRoot = contentUrl;
-  if (storeCode) {
-    storeRoot += `/${storeCode}`;
-  }
-  let sheetUrl = `${storeRoot}/${name}.json`
+  const { contentUrl } = context;
+  let sheetUrl = `${contentUrl}/${name}.json`
   if (sheet) {
     sheetUrl += `?sheet=${sheet}`;
   }
@@ -211,8 +207,9 @@ async function requestSpreadsheet(name, sheet, context) {
  * @returns {Promise<object>} configuration as object.
  */
 async function getConfig(context) {
-  const { configName = 'configs' } = context;
+  const { configName = 'configs', logger } = context;
   if (!context.config) {
+    logger.debug(`Fetching config ${configName}`);
     const configData = await requestSpreadsheet(configName, null, context);
     context.config = configData.data.reduce((acc, { key, value }) => ({ ...acc, [key]: value }), {});
   }

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -223,12 +223,11 @@ async function getConfig(context) {
  * @param {string} operationName name of the operation.
  * @param {object} variables query variables.
  * @param {object} context the context object.
- * @param {object} [configOverrides] optional object to overwrite config values.
  *
  * @returns {Promise<object>} GraphQL response as parsed object.
  */
-async function requestSaaS(query, operationName, variables, context, configOverrides = {}) {
-  const { storeUrl, logger } = context;
+async function requestSaaS(query, operationName, variables, context) {
+  const { storeUrl, logger, configOverrides = {} } = context;
   const config = {
     ... (await getConfig(context)),
     ...configOverrides

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -285,6 +285,65 @@ function isValidUrl(string) {
   }
 }
 
+/**
+ * Constructs the URL of a product.
+ *
+ * @param {Object} product Product with sku and urlKey properties.
+ * @param {Object} context The context object containing the store URL and path format.
+ * @returns {string} The product url or null if storeUrl or pathFormat are missing.
+ */
+function getProductUrl(product, context, addStore = true) {
+  const { storeUrl, pathFormat } = context;
+  if (!storeUrl || !pathFormat) {
+    return null;
+  }
+
+  const availableParams = {
+    sku: product.sku,
+    urlKey: product.urlKey,
+    locale: context.locale,
+  };
+
+  let path = pathFormat.split('/')
+    .filter(Boolean)
+    .map(part => {
+      if (part.startsWith('{') && part.endsWith('}')) {
+        const key = part.substring(1, part.length - 1);
+        return availableParams[key];
+      }
+      return part;
+    });
+
+  if (addStore) {
+    path.unshift(storeUrl);
+    return path.join('/');
+  }
+
+  return `/${path.join('/')}`;
+}
+
+/**
+ * Adjust the context according to the given locale.
+ * 
+ * TODO: Customize this function to match your multi store setup
+ * 
+ * @param {string} locale The locale to map.
+ * @returns {Object} An object containing the adjusted context.
+ */
+function mapLocale(locale, context) {
+  // List of allowed locales
+  const allowedLocales = ['en', 'fr'];
+  if (!locale || !allowedLocales.includes(locale)) {
+    locale = 'en';
+  }
+
+  // Example for dedicated config file per locale
+  return {
+    locale,
+    configName: [locale, context.configName].join('/'),
+  }
+}
+
 module.exports = {
   errorResponse,
   getBearerToken,
@@ -295,4 +354,6 @@ module.exports = {
   request,
   requestSpreadsheet,
   isValidUrl,
+  getProductUrl,
+  mapLocale,
 }

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -332,7 +332,7 @@ function getProductUrl(product, context, addStore = true) {
  */
 function mapLocale(locale, context) {
   // List of allowed locales
-  const allowedLocales = ['en', 'fr'];
+  const allowedLocales = ['en', 'fr']; // Or use context.allowedLocales derived from HLX_LOCALES configuration
   if (!locale || !allowedLocales.includes(locale)) {
     locale = 'en';
   }

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -8,9 +8,16 @@ application:
           LOG_LEVEL: debug
           HLX_CONTENT_URL: "https://main--aem-boilerplate-commerce--hlxsites.aem.live"
           HLX_PRODUCTS_TEMPLATE: "https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/default"
+          HLX_ORG_NAME: "hlxsites"
+          HLX_SITE_NAME: "aem-boilerplate-commerce"
           HLX_STORE_URL: "https://www.aemshop.net"
           HLX_CONFIG_NAME: "configs"
           HLX_PATH_FORMAT: "/products/{urlKey}/{sku}"
+          # HLX_LOCALES: comma-seprated list of allowed locales.
+          # i.e. us,uk,it,de,fr,es - or just one
+          # null if there is a single store and no
+          # URI prefixes are used
+          HLX_LOCALES: null
         actions:
           pdp-renderer:
             function: actions/pdp-renderer/index.js
@@ -28,19 +35,6 @@ application:
               memorySize: 128
               timeout: 3600000
             inputs:
-              LOG_LEVEL: debug
-              storeUrl: https://www.aemshop.net
-              orgName: hlxsites
-              siteName: aem-boilerplate-commerce
-              configName: configs
-              # storeCodes: comma-seprated list of store codes.
-              # i.e. us,uk,it,de,fr,es - or just one
-              # null if there is a single store and no
-              # URI prefixes are used
-              storeCodes: null
-              # PDPURIPrefix: URI prefix for the Product Pages
-              # i.e.: /products
-              PDPURIPrefix: /products
               authToken: ${AEM_ADMIN_API_AUTH_TOKEN}
             annotations:
               final: true

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -4,18 +4,18 @@ application:
     packages:
       aem-commerce-ssg:
         license: Apache-2.0
+        inputs:
+          LOG_LEVEL: debug
+          HLX_CONTENT_URL: "https://main--aem-boilerplate-commerce--hlxsites.aem.live"
+          HLX_PRODUCTS_TEMPLATE: "https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/default"
+          HLX_STORE_URL: "https://www.aemshop.net"
+          HLX_CONFIG_NAME: "configs"
+          HLX_PATH_FORMAT: "/products/{urlKey}/{sku}"
         actions:
           pdp-renderer:
             function: actions/pdp-renderer/index.js
             web: 'yes'
             runtime: nodejs:18
-            inputs:
-              LOG_LEVEL: debug
-              HLX_CONTENT_URL: "https://main--aem-boilerplate-commerce--hlxsites.aem.live"
-              HLX_PRODUCTS_TEMPLATE: "https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/default"
-              HLX_STORE_URL: "https://www.aemshop.net"
-              HLX_CONFIG_NAME: "configs"
-              HLX_PATH_FORMAT: "/products/{urlKey}/{sku}"
             annotations:
               final: true
             include:

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -9,7 +9,7 @@ describe('Poller', () => {
     assert.deepEqual(
       state,
       {
-        storeCode: 'uk',
+        locale: 'uk',
         skus: {},
         skusLastQueriedAt: new Date(0),
       }
@@ -23,7 +23,7 @@ describe('Poller', () => {
     assert.deepEqual(
       state,
       {
-        storeCode: 'uk',
+        locale: 'uk',
         skus: {
           sku1: new Date(2),
           sku2: new Date(3),
@@ -50,7 +50,7 @@ describe('Poller', () => {
     assert.deepEqual(newState, state);
   });
 
-  it('loadState after saveState with null storeCode', async () => {
+  it('loadState after saveState with null locale', async () => {
     const stateLib = new State(0);
     await stateLib.put('default', '1,sku1,2,sku2,3,sku3,4');
     const state = await loadState(null, stateLib);

--- a/test/ldJson.test.js
+++ b/test/ldJson.test.js
@@ -17,7 +17,7 @@ const { useMockServer, handlers } = require('./mock-server.js');
 
 describe('ldJson', () => {
 
-    const mockContext = { contentUrl: 'https://content.com', storeUrl: 'https://example.com', configName: 'config', logger: { error: jest.fn() }, pathFormat: '/products/{urlKey}/{sku}' };
+    const mockContext = { contentUrl: 'https://content.com', storeUrl: 'https://example.com', configName: 'config', logger: { debug: jest.fn(), error: jest.fn() }, pathFormat: '/products/{urlKey}/{sku}' };
     const server = useMockServer();
 
     beforeEach(() => {

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { findDescription, getPrimaryImage, extractPathDetails, getProductUrl, generatePriceString } = require('../actions/pdp-renderer/lib');
+const { findDescription, getPrimaryImage, extractPathDetails, generatePriceString } = require('../actions/pdp-renderer/lib');
 
 describe('lib', () => {
     test('findDescription', () => {
@@ -61,28 +61,6 @@ describe('lib', () => {
         });
         test('empty object for null path', () => {
             expect(extractPathDetails(null)).toEqual({});
-        });
-    });
-
-    describe('getProductUrl', () => {
-        test('getProductUrl with urlKey and sku', () => {
-            const context = { storeUrl: 'https://example.com', pathFormat: '/products/{urlKey}/{sku}' };
-            expect(getProductUrl({ urlKey: 'my-url-key', sku: 'my-sku' }, context)).toBe('https://example.com/products/my-url-key/my-sku');
-        });
-
-        test('getProductUrl with urlKey', () => {
-            const context = { storeUrl: 'https://example.com', pathFormat: '/{urlKey}' };
-            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe('https://example.com/my-url-key');
-        });
-
-        test('return null for missing storeUrl', () => {
-            const context = { pathFormat: '/{urlKey}' };
-            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe(null);
-        });
-
-        test('return null for missing pathFormat', () => {
-            const context = { storeUrl: 'https://example.com' };
-            expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe(null);
         });
     });
 

--- a/test/pdp-renderer.test.js
+++ b/test/pdp-renderer.test.js
@@ -158,6 +158,18 @@ describe('pdp-renderer', () => {
     expect(ldJson.offers[0].url).toEqual('https://store.com/en/products/24-MB03');
   });
 
+  test('return 400 if locale is not supported', async () => {
+    const response = await action.main({
+      HLX_STORE_URL: 'https://store.com',
+      HLX_CONTENT_URL: 'https://content.com',
+      HLX_CONFIG_NAME: 'config',
+      HLX_PATH_FORMAT: '/{locale}/products/{sku}',
+      __ow_path: `/test/products/24-MB03`,
+    });
+
+    expect(response.error.statusCode).toEqual(400);
+  });
+
   test('return 400 if neither sku nor urlKey are provided', async () => {
     const response = await action.main({
       HLX_STORE_URL: 'https://store.com',

--- a/test/pdp-renderer.test.js
+++ b/test/pdp-renderer.test.js
@@ -11,6 +11,8 @@ governing permissions and limitations under the License.
 */
 
 const cheerio = require('cheerio');
+const { http, HttpResponse } = require('msw');
+
 const { useMockServer, handlers } = require('./mock-server.js');
 
 jest.mock('@adobe/aio-sdk', () => ({
@@ -125,6 +127,35 @@ describe('pdp-renderer', () => {
    
     const $ = cheerio.load(response.body);
     expect($('body > main > div.product-details > div > div > h1').text()).toEqual('Crown Summit Backpack');
+  });
+
+  test('render product with locale', async () => {
+    server.use(handlers.defaultProduct());
+
+    let configRequestUrl;
+    const mockConfig = require('./mock-responses/mock-config.json');
+    server.use(http.get('https://content.com/en/config.json', async (req) => {
+      configRequestUrl = req.request.url;
+      return HttpResponse.json(mockConfig);
+    }));
+
+    const response = await action.main({
+      HLX_STORE_URL: 'https://store.com',
+      HLX_CONTENT_URL: 'https://content.com',
+      HLX_CONFIG_NAME: 'config',
+      HLX_PATH_FORMAT: '/{locale}/products/{sku}',
+      __ow_path: `/en/products/24-MB03`,
+    });
+
+    expect(configRequestUrl).toBe('https://content.com/en/config.json');
+
+    // Validate product
+    const $ = cheerio.load(response.body);
+    expect($('body > main > div.product-details > div > div > h1').text()).toEqual('Crown Summit Backpack');
+
+    // Validate product url in structured data
+    const ldJson = JSON.parse($('head > script[type="application/ld+json"]').html());
+    expect(ldJson.offers[0].url).toEqual('https://store.com/en/products/24-MB03');
   });
 
   test('return 400 if neither sku nor urlKey are provided', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -128,7 +128,17 @@ describe('request', () => {
       return HttpResponse.json({ data: [{ key: 'testKey', value: 'testValue' }] });
     }));
 
-    const context = { contentUrl: 'https://content.com' };
+    const context = { contentUrl: 'https://content.com', logger: { debug: jest.fn() } };
+    const config = await getConfig(context);
+    expect(config).toEqual({ testKey: 'testValue' });
+  });
+
+  test('getConfig with subpath', async () => {
+    server.use(http.get('https://content.com/en/configs.json', async () => {
+      return HttpResponse.json({ data: [{ key: 'testKey', value: 'testValue' }] });
+    }));
+
+    const context = { configName: 'en/configs', contentUrl: 'https://content.com', logger: { debug: jest.fn() } };
     const config = await getConfig(context);
     expect(config).toEqual({ testKey: 'testValue' });
   });
@@ -211,25 +221,25 @@ describe('request', () => {
   });
 
   test('requestSpreadsheet', async () => {
-    server.use(http.get('https://content.com/test/config.json', async () => {
+    server.use(http.get('https://content.com/config.json', async () => {
       return HttpResponse.json({ data: [{ key: 'testKey', value: 'testValue' }] });
     }));
 
-    const context = { contentUrl: 'https://content.com', storeCode: 'test' };
+    const context = { contentUrl: 'https://content.com' };
     const data = await requestSpreadsheet('config', null, context);
     expect(data).toEqual({ data: [{ key: 'testKey', value: 'testValue' }] });
   });
 
   test('requestSpreadsheet with sheet', async () => {
     let requestUrl;
-    server.use(http.get('https://content.com/test2/config.json', async ({ request }) => {
+    server.use(http.get('https://content.com/config.json', async ({ request }) => {
       requestUrl = request.url;
       return HttpResponse.json({ data: [{ key: 'testKey', value: 'testValue' }] });
     }));
 
-    const context = { contentUrl: 'https://content.com', storeCode: 'test2' };
+    const context = { contentUrl: 'https://content.com' };
     await requestSpreadsheet('config', 'testSheet', context);
-    expect(requestUrl).toEqual('https://content.com/test2/config.json?sheet=testSheet');
+    expect(requestUrl).toEqual('https://content.com/config.json?sheet=testSheet');
   });
 
   test('successful request', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const { useMockServer } = require('./mock-server');
-const { errorResponse, stringParameters, checkMissingRequestInputs, getBearerToken, request, requestSpreadsheet, getConfig, requestSaaS } = require('./../actions/utils.js');
+const { errorResponse, stringParameters, checkMissingRequestInputs, getBearerToken, request, requestSpreadsheet, getConfig, requestSaaS, getProductUrl } = require('./../actions/utils.js');
 const { http, HttpResponse } = require('msw');
 
 test('interface', () => {
@@ -265,5 +265,32 @@ describe('request', () => {
     }));
 
     await expect(request('testRequest', 'https://example.com/timeout', {}, 100)).rejects.toThrow('This operation was aborted');
+  });
+});
+
+describe('getProductUrl', () => {
+  test('getProductUrl with urlKey and sku', () => {
+      const context = { storeUrl: 'https://example.com', pathFormat: '/products/{urlKey}/{sku}' };
+      expect(getProductUrl({ urlKey: 'my-url-key', sku: 'my-sku' }, context)).toBe('https://example.com/products/my-url-key/my-sku');
+  });
+
+  test('getProductUrl with urlKey', () => {
+      const context = { storeUrl: 'https://example.com', pathFormat: '/{urlKey}' };
+      expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe('https://example.com/my-url-key');
+  });
+
+  test('return null for missing storeUrl', () => {
+      const context = { pathFormat: '/{urlKey}' };
+      expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe(null);
+  });
+
+  test('return null for missing pathFormat', () => {
+      const context = { storeUrl: 'https://example.com' };
+      expect(getProductUrl({ urlKey: 'my-url-key' }, context)).toBe(null);
+  });
+
+  test('getProductUrl with path only', () => {
+      const context = { storeUrl: 'https://example.com', pathFormat: '/{locale}/products/{urlKey}/{sku}', locale: 'de' };
+      expect(getProductUrl({ urlKey: 'my-url-key', sku: 'my-sku' }, context, false)).toBe('/de/products/my-url-key/my-sku');
   });
 });


### PR DESCRIPTION
* Extended `HLX_PATH_FORMAT` to support a `locale` parameter. 
* The `locale` can adjust the `context` using a custom `mapLocale` method that is called.
* This allows for:
    * Select a different config per locale, e.g. to load a config from `aemshop.net/en/configs.json`.
    * Override certain config parameters per locale, e.g. to change to store code.
* Moved project configuration parameters up from actions to the project so it can be re-used by all actions.
    * Adapted poller and renderer to use the same configuration parameters.
* Added tests.

Only merge after #18.