### PR TITLE
fix: more resilient state management

### DIFF
--- a/actions/check-product-changes/index.js
+++ b/actions/check-product-changes/index.js
@@ -10,12 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const { Core } = require('@adobe/aio-sdk');
 const { stateLib } = require('@adobe/aio-lib-state');
 const { poll } = require('./poller');
+const { StateManager } = require('./lib/state');
 
 async function main(params) {
   const state = await stateLib.init();
-  const running = await state.get('running');
+
+  const logger = Core.Logger('main', { level: params.LOG_LEVEL || 'info' });
+  const stateMgr = new StateManager(state, { logger });
+
+  const running = await stateMgr.get('running');
 
   if (running?.value === 'true') {
     return { state: 'skipped' };
@@ -25,10 +31,10 @@ async function main(params) {
     // if there is any failure preventing a reset of the 'running' state key to 'false',
     // this might not be updated and action execution could be permanently skipped
     // a ttl == function timeout is a mitigation for this risk
-    await state.put('running', 'true', { ttl: 3600 });
+    await stateMgr.put('running', 'true', 3600);
     return await poll(params, state);
   } finally {
-    await state.put('running', 'false');
+    await stateMgr.put('running', 'false');
   }
 }
 

--- a/actions/check-product-changes/index.js
+++ b/actions/check-product-changes/index.js
@@ -22,7 +22,10 @@ async function main(params) {
   }
 
   try {
-    await state.put('running', 'true');
+    // if there is any failure preventing a reset of the 'running' state key to 'false',
+    // this might not be updated and action execution could be permanently skipped
+    // a ttl == function timeout is a mitigation for this risk
+    await state.put('running', 'true', { ttl: 3600 });
     return await poll(params, state);
   } finally {
     await state.put('running', 'false');

--- a/actions/check-product-changes/lib/state.js
+++ b/actions/check-product-changes/lib/state.js
@@ -1,0 +1,63 @@
+
+class StateManager {
+    /**
+     * Constructs a new StateManager instance.
+     * @param {number} [retryCount=5] - Number of retry attempts for failed operations (default: 5).
+     * @param {number} [retryDelay=1] - Delay between retries in seconds (default: 10s).
+     */
+    constructor(state, { logger }, retryCount = 5, retryDelay = 10) {
+        this.retryCount = retryCount > 0 ? retryCount : 1;
+        this.retryDelay = retryDelay * 1000;
+        this.logger = logger;
+        this.state = state;
+    }
+
+    /**
+     * Retrieves a value from the state library.
+     * @param {string} key - The key to retrieve the value for.
+     * @returns {Promise<any>} - The value associated with the key.
+     * @throws {Error} - If the operation fails after all retry attempts.
+     */
+    async get(key) {
+        return this._retry(async () => await this.state.get(key));
+    }
+
+    /**
+     * Sets a key-value pair in the state library.
+     * Retries the operation in case of failure up to the configured retry count.
+     * @param {string} key - The key to set.
+     * @param {string} value - The value to associate with the key.
+     * @param {number} [ttl=86400] Entry expiration time in seconds. (default: 86400s (24h)).
+     * @returns {Promise<string>} - Key for entry
+     * @throws {Error} - If the operation fails after all retry attempts.
+     */
+    async put(key, value, ttl = 86400) {
+        return this._retry(async () => await this.state.put(key, value, { ttl: ttl }));
+    }
+
+    /**
+     * Internal method to retry an operation with delay and max retries.
+     * @private
+     * @param {Function} operation - The asynchronous operation to execute.
+     * @returns {Promise<any>} - The result of the operation if successful.
+     * @throws {Error} - If the operation fails after all retry attempts.
+     */
+    async _retry(operation) {
+        let attempt = 0;
+        let lastError = null;
+        while (attempt < this.retryCount) {
+            try {
+                return await operation();
+            } catch (error) {
+                lastError = error;
+                attempt++;
+                this.logger.warning(`State error encountered, attempting retry ${attempt}: ${error.message}`);
+                await new Promise((r) => setTimeout(r, this.retryDelay));
+            }
+        }
+        this.logger.error(`Fatal state error giving up.`);
+        throw lastError;
+    }
+}
+
+module.exports = { StateManager };

--- a/test/__mocks__/state.js
+++ b/test/__mocks__/state.js
@@ -1,21 +1,21 @@
-class State {
-    internalState = {};
-  
-    constructor(stateLatency = 200) {
-      this.stateLatency = stateLatency;
-    }
-  
-    async get(key) {
-      return new Promise((resolve) => {
-        setTimeout(() => resolve({ value: this.internalState[key] }), this.stateLatency);
-      });
-    }
-  
-    async put(key, value) {
-      return new Promise((resolve) => {
-        setTimeout(() => resolve(this.internalState[key] = value), this.stateLatency);
-      });
-    }
+class MockState {
+  internalState = {};
+
+  constructor(stateLatency = 200) {
+    this.stateLatency = stateLatency;
   }
-  
-  module.exports = State;
+
+  async get(key) {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve({ value: this.internalState[key] }), this.stateLatency);
+    });
+  }
+
+  async put(key, value) {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(this.internalState[key] = value), this.stateLatency);
+    });
+  }
+}
+
+module.exports = { MockState };

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -1,11 +1,20 @@
 const assert = require('node:assert/strict');
 const { loadState, saveState } = require('../actions/check-product-changes/poller.js');
-const State = require('./__mocks__/state.js');
+const { StateManager } = require('../actions/check-product-changes/lib/state.js');
+const { MockState } = require('./__mocks__/state.js');
+
+
+const logger = { debug: () => {}, info: () => {}, error: () => {} };
+
+const createStateManager = () => {
+  const stateLib = new MockState(0);
+  return new StateManager(stateLib, logger);
+}
 
 describe('Poller', () => {
   it('loadState returns default state', async () => {
-    const stateLib = new State(0);
-    const state = await loadState('uk', stateLib);
+    const stateMgr = createStateManager();
+    const state = await loadState('uk', stateMgr);
     assert.deepEqual(
       state,
       {
@@ -17,9 +26,9 @@ describe('Poller', () => {
   });
 
   it('loadState returns parsed state', async () => {
-    const stateLib = new State(0);
-    await stateLib.put('uk', '1,sku1,2,sku2,3,sku3,4');
-    const state = await loadState('uk', stateLib);
+    const stateMgr = createStateManager();
+    await stateMgr.put('uk', '1,sku1,2,sku2,3,sku3,4');
+    const state = await loadState('uk', stateMgr);
     assert.deepEqual(
       state,
       {
@@ -35,31 +44,31 @@ describe('Poller', () => {
   });
 
   it('loadState after saveState', async () => {
-    const stateLib = new State(0);
-    await stateLib.put('uk', '1,sku1,2,sku2,3,sku3,4');
-    const state = await loadState('uk', stateLib);
+    const stateMgr = createStateManager();
+    await stateMgr.put('uk', '1,sku1,2,sku2,3,sku3,4');
+    const state = await loadState('uk', stateMgr);
     state.skusLastQueriedAt = new Date(5);
     state.skus['sku1'] = new Date(5);
     state.skus['sku2'] = new Date(6);
-    await saveState(state, stateLib);
+    await saveState(state, stateMgr);
 
-    const serializedState = await stateLib.get('uk');
+    const serializedState = await stateMgr.get('uk');
     assert.equal(serializedState?.value, '5,sku1,5,sku2,6,sku3,4');
 
-    const newState = await loadState('uk', stateLib);
+    const newState = await loadState('uk', stateMgr);
     assert.deepEqual(newState, state);
   });
 
   it('loadState after saveState with null storeCode', async () => {
-    const stateLib = new State(0);
-    await stateLib.put('default', '1,sku1,2,sku2,3,sku3,4');
-    const state = await loadState(null, stateLib);
+    const stateMgr = createStateManager();
+    await stateMgr.put('default', '1,sku1,2,sku2,3,sku3,4');
+    const state = await loadState(null, stateMgr);
     state.skusLastQueriedAt = new Date(5);
     state.skus['sku1'] = new Date(5);
     state.skus['sku2'] = new Date(6);
-    await saveState(state, stateLib);
+    await saveState(state, stateMgr);
 
-    const serializedState = await stateLib.get('default');
+    const serializedState = await stateMgr.get('default');
     assert.equal(serializedState?.value, '5,sku1,5,sku2,6,sku3,4');
   });
 });


### PR DESCRIPTION
If there is any failure preventing a reset of the 'running' state key to 'false', this might not be updated and action execution could be permanently skipped; a ttl == function timeout is a mitigation for this risk
In addition to this, a StateManager was introduced in order to properly manage failures in state.put and state.get calls, which might otherwise lead to a deadlock or other concurrency issues

https://cq-dev.slack.com/archives/C085GHFR6F4/p1737633418400839