### PR TITLE
feat: store skus and last previewed in files storage

### DIFF
--- a/actions/check-product-changes/index.js
+++ b/actions/check-product-changes/index.js
@@ -10,22 +10,23 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { stateLib } = require('@adobe/aio-lib-state');
+const { State, Files } = require('@adobe/aio-sdk');
 const { poll } = require('./poller');
 
 async function main(params) {
-  const state = await stateLib.init();
-  const running = await state.get('running');
+  const stateLib = await State.init();
+  const filesLib = await Files.init();
+  const running = await stateLib.get('running');
 
   if (running?.value === 'true') {
     return { state: 'skipped' };
   }
 
   try {
-    await state.put('running', 'true');
-    return await poll(params, state);
+    await stateLib.put('running', 'true');
+    return await poll(params, filesLib);
   } finally {
-    await state.put('running', 'false');
+    await stateLib.put('running', 'false');
   }
 }
 

--- a/test/__mocks__/files.js
+++ b/test/__mocks__/files.js
@@ -1,0 +1,21 @@
+class Files {
+  internalStorage = {};
+
+  constructor(storageLatency = 500) {
+    this.storageLatency = storageLatency;
+  }
+
+  async read(fileLocation) {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(this.internalStorage[fileLocation]), this.storageLatency);
+    });
+  }
+
+  async write(fileLocation, fileData) {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(this.internalStorage[fileLocation] = fileData), this.storageLatency);
+    });
+  }
+}
+
+module.exports = Files;

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -1,11 +1,11 @@
 const assert = require('node:assert/strict');
-const { loadState, saveState } = require('../actions/check-product-changes/poller.js');
-const State = require('./__mocks__/state.js');
+const { loadState, saveState, getFileLocation } = require('../actions/check-product-changes/poller.js');
+const Files = require('./__mocks__/files.js');
 
 describe('Poller', () => {
   it('loadState returns default state', async () => {
-    const stateLib = new State(0);
-    const state = await loadState('uk', stateLib);
+    const filesLib = new Files(0);
+    const state = await loadState('uk', filesLib);
     assert.deepEqual(
       state,
       {
@@ -17,9 +17,9 @@ describe('Poller', () => {
   });
 
   it('loadState returns parsed state', async () => {
-    const stateLib = new State(0);
-    await stateLib.put('uk', '1,sku1,2,sku2,3,sku3,4');
-    const state = await loadState('uk', stateLib);
+    const filesLib = new Files(0);
+    await filesLib.write(getFileLocation('uk'), '1,sku1,2,sku2,3,sku3,4');
+    const state = await loadState('uk', filesLib);
     assert.deepEqual(
       state,
       {
@@ -35,31 +35,31 @@ describe('Poller', () => {
   });
 
   it('loadState after saveState', async () => {
-    const stateLib = new State(0);
-    await stateLib.put('uk', '1,sku1,2,sku2,3,sku3,4');
-    const state = await loadState('uk', stateLib);
+    const filesLib = new Files(0);
+    await filesLib.write(getFileLocation('uk'), '1,sku1,2,sku2,3,sku3,4');
+    const state = await loadState('uk', filesLib);
     state.skusLastQueriedAt = new Date(5);
     state.skus['sku1'] = new Date(5);
     state.skus['sku2'] = new Date(6);
-    await saveState(state, stateLib);
+    await saveState(state, filesLib);
 
-    const serializedState = await stateLib.get('uk');
-    assert.equal(serializedState?.value, '5,sku1,5,sku2,6,sku3,4');
+    const serializedState = await filesLib.read(getFileLocation('uk'));
+    assert.equal(serializedState, '5,sku1,5,sku2,6,sku3,4');
 
-    const newState = await loadState('uk', stateLib);
+    const newState = await loadState('uk', filesLib);
     assert.deepEqual(newState, state);
   });
 
   it('loadState after saveState with null storeCode', async () => {
-    const stateLib = new State(0);
-    await stateLib.put('default', '1,sku1,2,sku2,3,sku3,4');
-    const state = await loadState(null, stateLib);
+    const filesLib = new Files(0);
+    await filesLib.write(getFileLocation('default'), '1,sku1,2,sku2,3,sku3,4');
+    const state = await loadState(null, filesLib);
     state.skusLastQueriedAt = new Date(5);
     state.skus['sku1'] = new Date(5);
     state.skus['sku2'] = new Date(6);
-    await saveState(state, stateLib);
+    await saveState(state, filesLib);
 
-    const serializedState = await stateLib.get('default');
-    assert.equal(serializedState?.value, '5,sku1,5,sku2,6,sku3,4');
+    const serializedState = await filesLib.read(getFileLocation('default'));
+    assert.equal(serializedState, '5,sku1,5,sku2,6,sku3,4');
   });
 });


### PR DESCRIPTION
State lib can only hold value of size 1MB max. It's possible that customers have many SKUs and the state size got to more than 1MB. In addition, state lib is more expensive for the usage than files lib, without a clear advantage for this use case.