### PR TITLE
sites-28868 updated request headers

### DIFF
--- a/actions/check-product-changes/lib/aem.js
+++ b/actions/check-product-changes/lib/aem.js
@@ -111,6 +111,7 @@ class AdminAPI {
         const adminUrl = `https://admin.hlx.page/${route}/${this.org}/${this.site}/main${path}`;
 
         const req = { method, headers: {} };
+        req.headers['User-Agent'] = 'AEM Commerce Poller / 1.0';
         if (body) {
             req.body = JSON.stringify(body);
             req.headers['content-type'] = 'application/json';

--- a/test/aem.test.js
+++ b/test/aem.test.js
@@ -80,6 +80,7 @@ describe('AdminAPI Optimized Tests', () => {
             headers: {
                 'content-type': 'application/json',
                 'x-auth-token': 'testToken',
+                'User-Agent': 'AEM Commerce Poller / 1.0',
             },
             body: JSON.stringify({ data: 'test' }),
         });


### PR DESCRIPTION
updated request header to include "AEM Commerce Poller / 1.0" to help identify itself.

Update aem.test.js to expect the new "AEM Commerce Poller / 1.0" header