### PR TITLE
feat: implement html diff

### DIFF
--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -15,6 +15,8 @@ const { AdminAPI } = require('./lib/aem');
 const { requestSaaS, requestSpreadsheet, isValidUrl, getProductUrl, mapLocale } = require('../utils');
 const { GetAllSkusQuery, GetLastModifiedQuery } = require('../queries');
 const { Core } = require('@adobe/aio-sdk');
+const { generateProductHtml } = require('../pdp-renderer/render');
+const crypto = require('crypto');
 
 const BATCH_SIZE = 50;
 const STATE_FILE_PREFIX = 'check-product-changes';
@@ -70,7 +72,7 @@ async function loadState(locale, aioLibs) {
         // ...
         // each row is a set of SKUs, last previewed timestamp and hash
         const [sku, time, hash] = line.split(',');
-        acc[sku] = { time: new Date(parseInt(time)), hash };
+        acc[sku] = { lastPreviewedAt: new Date(parseInt(time)), hash };
         return acc;
       }, {});
     } else {
@@ -100,7 +102,7 @@ async function saveState(state, aioLibs) {
   const fileLocation = getStateFileLocation(stateKey);
   const csvData = [
     ...Object.entries(state.skus)
-      .map(([sku, { time, hash }]) => `${sku},${time.getTime()},${hash || ''}`),
+      .map(([sku, { lastPreviewedAt, hash }]) => `${sku},${lastPreviewedAt.getTime()},${hash || ''}`),
   ].join('\n');
   return await filesLib.write(fileLocation, csvData);
 }
@@ -129,6 +131,7 @@ async function deleteState(locale, filesLib) {
  * @param {string} params.PLPURIPrefix - The URI prefix for Product List Pages.
  * @param {string} params.HLX_ORG_NAME - The name of the organization.
  * @param {string} params.HLX_CONFIG_NAME - The name of the configuration json/xlsx.
+ * @param {string} params.HLX_PRODUCTS_TEMPLATE URL to the products template page
  * @param {number} [params.requestPerSecond=5] - The number of requests per second allowed by the throttling logic.
  * @param {string} params.authToken - The authentication token.
  * @param {number} [params.skusRefreshInterval=600000] - The interval for refreshing SKUs in milliseconds.
@@ -166,8 +169,110 @@ async function deleteBatch({ counts, batch, state, adminApi }) {
 }
 
 function shouldProcessProduct(product) {
-  const { urlKey, lastModifiedDate, lastPreviewDate } = product;
-  return urlKey?.match(/^[a-zA-Z0-9-]+$/) && lastModifiedDate >= lastPreviewDate;
+  const { urlKey, lastModifiedDate, lastPreviewDate, currentHash, newHash } = product;
+  return urlKey?.match(/^[a-zA-Z0-9-]+$/) && lastModifiedDate >= lastPreviewDate && currentHash !== newHash;
+}
+
+/**
+ * Processes a product to determine if it needs to be updated
+ * @param {Object} product - The product to process
+ * @param {Object} state - The current state
+ * @returns {Object} Enhanced product with additional metadata
+ */
+async function enrichProductWithMetadata(product, state, context) {
+  const { sku, urlKey, lastModifiedAt } = product;
+  const lastPreviewDate = state.skus[sku]?.lastPreviewedAt || new Date(0);
+  const lastModifiedDate = new Date(lastModifiedAt);
+  const productHtml = await generateProductHtml(sku, urlKey, context);
+  const newHash = crypto.createHash('sha256').update(productHtml).digest('hex');
+
+  return { 
+    ...product, 
+    lastModifiedDate, 
+    lastPreviewDate, 
+    currentHash: state.skus[sku]?.hash || null, 
+    newHash 
+  };
+}
+
+/**
+ * Creates batches of products that need to be processed
+ * @param {Array} products - List of products to process
+ * @param {Object} context - The context object
+ * @param {AdminAPI} adminApi - The admin API instance
+ * @returns {Array} Batches of products to process
+ */
+function createPublishBatches(products, context, adminApi) {
+  return products.filter(shouldProcessProduct)
+    .reduce((acc, product) => {
+      const { sku, urlKey } = product;
+      const path = getProductUrl({ urlKey, sku }, context, false).toLowerCase();
+      const req = adminApi.previewAndPublish({ path, sku });
+
+      if (!acc.length || acc[acc.length - 1].length === BATCH_SIZE) {
+        acc.push([]);
+      }
+      acc[acc.length - 1].push(req);
+
+      return acc;
+    }, []);
+}
+
+/**
+ * Processes publish batches and updates state
+ * @param {Array} batches - Batches of products to process
+ * @param {Object} state - The current state
+ * @param {Object} counts - Counters for operations
+ * @param {Array} products - Original product data
+ * @param {Object} aioLibs - AIO libraries
+ * @returns {Promise<void>}
+ */
+async function processPublishBatches(batches, state, counts, products, aioLibs) {
+  for (const batch of batches) {
+    const response = await Promise.all(batch);
+    for (const { sku, previewedAt, publishedAt } of response) {
+      if (previewedAt && publishedAt) {
+        const product = products.find(p => p.sku === sku);
+        state.skus[sku] = { 
+          lastPreviewedAt: previewedAt, 
+          hash: product?.newHash 
+        };
+        counts.published++;
+      } else {
+        counts.failed++;
+      }
+    }
+    await saveState(state, aioLibs);
+  }
+}
+
+/**
+ * Identifies and processes products that need to be deleted
+ * @param {Array} remainingSkus - SKUs that weren't found in catalog
+ * @param {Object} state - The current state
+ * @param {Object} counts - Counters for operations
+ * @param {Object} context - The context object
+ * @param {AdminAPI} adminApi - The admin API instance
+ * @param {Object} aioLibs - AIO libraries
+ * @param {Object} logger - Logger instance
+ * @returns {Promise<void>}
+ */
+async function processDeletedProducts(remainingSkus, state, counts, context, adminApi, aioLibs, logger) {
+  if (!remainingSkus.length) return;
+  
+  try {
+    const publishedProducts = await requestSpreadsheet('published-products-index', null, context);
+    const deletedProducts = publishedProducts.data.filter(({ sku }) => remainingSkus.includes(sku));
+    
+    // Process in batches
+    for (let i = 0; i < deletedProducts.length; i += BATCH_SIZE) {
+      const batch = deletedProducts.slice(i, i + BATCH_SIZE);
+      await deleteBatch({ counts, batch, state, adminApi });
+      await saveState(state, aioLibs);
+    }
+  } catch (e) {
+    logger.error('Error processing deleted products:', e);
+  }
 }
 
 async function poll(params, aioLibs) {
@@ -179,6 +284,7 @@ async function poll(params, aioLibs) {
     HLX_PATH_FORMAT: pathFormat,
     HLX_ORG_NAME: orgName,
     HLX_CONFIG_NAME: configName,
+    HLX_PRODUCTS_TEMPLATE: productsTemplate,
     requestPerSecond = 5,
     authToken,
     skusRefreshInterval = 600000,
@@ -215,20 +321,18 @@ async function poll(params, aioLibs) {
         context = { ...context, ...mapLocale(locale, context) };
       }
 
-      // setup preview / publish queues
-
-      // get all skus
-      // check if the skus were last queried within the last 10 minutes
+      // Refresh SKUs if needed
       if (timings.now - state.skusLastQueriedAt >= skusRefreshInterval) {
         state.skusLastQueriedAt = new Date();
         const allSkusResp = await requestSaaS(GetAllSkusQuery, 'getAllSkus', {}, context);
         const allSkus = allSkusResp.data.productSearch.items
           .map(({ productView }) => productView || {})
           .filter(Boolean);
+        
         // add new skus to state if any
         for (const sku of allSkus) {
           if (!state.skus[sku]) {
-            state.skus[sku] = { time: new Date(0), hash: null };
+            state.skus[sku] = { lastPreviewedAt: new Date(0), hash: null };
           }
         }
         timings.sample('fetchedSkus');
@@ -242,91 +346,43 @@ async function poll(params, aioLibs) {
       timings.sample('fetchedLastModifiedDates');
       logger.info(`Fetched last modified date for ${lastModifiedResp.data.products.length} skus, total ${skus.length}`);
 
-      // group preview in batches of 50
-      let products = lastModifiedResp.data.products
-        .map((product) => {
-          const { sku, lastModifiedAt } = product;
-          const lastPreviewedAt = state.skus[sku].time || 0;
-          const lastPreviewDate = new Date(lastPreviewedAt);
-          const lastModifiedDate = new Date(lastModifiedAt);
+      // Enrich products with metadata
+      const products = await Promise.all(
+        lastModifiedResp.data.products.map(product => 
+          enrichProductWithMetadata(product, state, context)
+        )
+      );
 
-          return { ...product, lastModifiedDate, lastPreviewDate };
-        }) // inject the lastModifiedDate and lastPreviewDate into the product object
-
-      products.forEach((product) => {
+      // Track remaining SKUs for deletion processing
+      const remainingSkus = [...skus];
+      products.forEach(product => {
         const { sku } = product;
         // remove the sku from the list of currently known skus
-        skus.splice(skus.indexOf(sku), 1);
+        const index = remainingSkus.indexOf(sku);
+        if (index !== -1) {
+          remainingSkus.splice(index, 1);
+        }
 
         // increment count of ignored products if condition is not met
         if (!shouldProcessProduct(product)) counts.ignored += 1;
-      })
+      });
 
-      const batches = products.filter(shouldProcessProduct)
-        .reduce((acc, product) => {
-          const { sku, urlKey } = product;
-          const path = getProductUrl({ urlKey, sku }, context, false).toLowerCase();
-          const req = adminApi.previewAndPublish({ path, sku });
-
-          if (!acc.length || acc[acc.length - 1].length === BATCH_SIZE) {
-            acc.push([]);
-          }
-          acc[acc.length - 1].push(req);
-
-          return acc;
-        }, []);
-
-      // preview batches , then save state in case we get interrupted
-      for (const batch of batches) {
-        const response = await Promise.all(batch);
-        for (const { sku, previewedAt, publishedAt } of response) {
-          if (previewedAt && publishedAt) {
-            state.skus[sku] = { time: previewedAt, hash: null };
-            counts.published++;
-          } else {
-            counts.failed++;
-          }
-        }
-        await saveState(state, aioLibs);
-      }
-
+      // Create and process publish batches
+      const batches = createPublishBatches(products, context, adminApi);
+      await processPublishBatches(batches, state, counts, products, aioLibs);
       timings.sample('publishedPaths');
 
-      // if there are still skus left, they were not in Catalog Service and may
-      // have been disabled/deleted
-      if (skus.length) {
-        try {
-          const publishedProducts = await requestSpreadsheet('published-products-index', null, context);
-          // if any of the indexed PDPs is in the remaining list of skus that were not returned by the catalog service
-          // consider them deleted
-          const deletedProducts = publishedProducts.data.filter(({ sku }) => skus.includes(sku));
-          // we batch the deleted products to avoid the risk of HTTP 429 from the AEM Admin API
-          if (deletedProducts.length) {
-            // delete in batches of BATCH_SIZE, then save state in case we get interrupted
-            let batch = [];
-            for (const product of deletedProducts) {
-              batch.push(product);
-              if (batch.length === BATCH_SIZE) {
-                // deleteBatch has side effects on state and counts, by design
-                await deleteBatch({ counts, batch, state, adminApi });
-                batch = [];
-              }
-            }
-            if (batch.length > 0) {
-              await deleteBatch({ counts, batch, state, adminApi });
-            }
-            // save state after deletes
-            await saveState(state, aioLibs);
-          }
-        } catch (e) {
-          // in case the index doesn't yet exist or any other error
-          logger.error(e);
-        }
-
-        timings.sample('unpublishedPaths');
-      } else {
-        timings.sample('unpublishedPaths', 0);
-      }
+      // Process deleted products
+      await processDeletedProducts(
+        remainingSkus, 
+        state, 
+        counts, 
+        context, 
+        adminApi, 
+        aioLibs, 
+        logger
+      );
+      timings.sample('unpublishedPaths', remainingSkus.length ? undefined : 0);
 
       return timings.measures;
     }));

--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -296,7 +296,7 @@ async function poll(params, aioLibs) {
     published: 0, unpublished: 0, ignored: 0, failed: 0,
   };
   const sharedContext = {
-    storeUrl, configName, logger, counts, pathFormat,
+    storeUrl, configName, logger, counts, pathFormat, productsTemplate,
   };
   const timings = new Timings();
   const adminApi = new AdminAPI({

--- a/actions/pdp-renderer/index.js
+++ b/actions/pdp-renderer/index.js
@@ -10,30 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const fs = require('fs');
-const path = require('path');
-
 const { Core } = require('@adobe/aio-sdk')
-const Handlebars = require('handlebars');
-const { errorResponse, stringParameters, requestSaaS, mapLocale } = require('../utils');
-const { extractPathDetails, findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceString, getImageList } = require('./lib');
-const { ProductQuery, ProductByUrlKeyQuery } = require('../queries');
-const { generateLdJson } = require('./ldJson');
-
-function toTemplateProductData(baseProduct) {
-  const templateProductData = { ...baseProduct };
-  const primaryImage = getPrimaryImage(baseProduct)?.url;
-
-  templateProductData.hasImages = baseProduct.images?.length > 0;
-  templateProductData.imageList = getImageList(primaryImage, baseProduct.images);
-  templateProductData.priceString = generatePriceString(baseProduct);
-  templateProductData.metaDescription = findDescription(baseProduct);
-  templateProductData.metaImage = primaryImage;
-  templateProductData.primaryImage = primaryImage;
-  templateProductData.metaTitle = baseProduct.metaTitle || baseProduct.name || 'Product Details';
-
-  return templateProductData;
-}
+const { errorResponse, stringParameters, mapLocale } = require('../utils');
+const { extractPathDetails } = require('./lib');
+const { generateProductHtml } = require('./render');
 
 /**
  * Parameters
@@ -74,9 +54,9 @@ async function main (params) {
     const configName = configNameQuery || HLX_CONFIG_NAME;
     const contentUrl = contentUrlQuery || HLX_CONTENT_URL;
     const storeUrl = storeUrlQuery || HLX_STORE_URL || contentUrl;
-    const productsTemplate = productsTemplateQuery || HLX_PRODUCTS_TEMPLATE;
     const allowedLocales = HLX_LOCALES ? HLX_LOCALES.split(',').map(a => a.trim()) : [];
     let context = { contentUrl, storeUrl, configName, logger, pathFormat, allowedLocales };
+    context.productsTemplate = productsTemplateQuery || HLX_PRODUCTS_TEMPLATE;
 
     const result = extractPathDetails(__ow_path, pathFormat);
     logger.debug('Path parse results', JSON.stringify(result, null, 4));
@@ -97,60 +77,22 @@ async function main (params) {
     }
 
     // Retrieve base product
-    let baseProduct;
-    if (sku) {
-      const baseProductData = await requestSaaS(ProductQuery, 'ProductQuery', { sku: sku.toUpperCase() }, context);
-      if (!baseProductData?.data?.products || baseProductData?.data?.products?.length === 0) {
-        return errorResponse(404, 'Product not found', logger);
-      }
-      baseProduct = baseProductData.data.products[0];
-    } else if (urlKey) {
-      const baseProductData = await requestSaaS(ProductByUrlKeyQuery, 'ProductByUrlKey', { urlKey }, context);
-      if (!baseProductData?.data?.productSearch || baseProductData?.data?.productSearch?.items?.length === 0) {
-        return errorResponse(404, 'Product not found', logger);
-      }
-      baseProduct = baseProductData.data.productSearch.items[0].productView;
-    }
-    logger.debug('Retrieved base product', JSON.stringify(baseProduct, null, 4));
-
-    // Assign meta tag data for template
-    const templateProductData = toTemplateProductData(baseProduct);
-
-    // Generate LD-JSON
-    const ldJson = await generateLdJson(baseProduct, context);
-
-    // Load the Handlebars template
-    const [pageHbs, headHbs, productDetailsHbs] = ['page', 'head', 'product-details'].map((template) => fs.readFileSync(path.join(__dirname, 'templates', `${template}.hbs`), 'utf8'));
-    const pageTemplate = Handlebars.compile(pageHbs);
-    Handlebars.registerPartial('head', headHbs);
-
-    if (productsTemplate) {
-      // Retrieve default product page as template
-      const blocksToReplace = [
-        'product-details',
-      ];
-      const baseTemplate = await prepareBaseTemplate(productsTemplate, blocksToReplace);
-
-      Handlebars.registerPartial('product-details', productDetailsHbs);
-      Handlebars.registerPartial('content', baseTemplate);
-    } else {
-      // Use product details block as sole content if no products template is defined
-      Handlebars.registerPartial('content', productDetailsHbs);
-    }
+    const productHtml = await generateProductHtml(sku, urlKey, context);
 
     const response = {
       statusCode: 200,
-      body: pageTemplate({
-        ...templateProductData,
-        ldJson,
-      }),
+      body: productHtml,
     }
     logger.info(`${response.statusCode}: successful request`)
     return response;
 
   } catch (error) {
     logger.error(error)
-    return errorResponse(500, 'server error', logger)
+    // Return appropriate status code if specified
+    if (error.statusCode) {
+      return errorResponse(error.statusCode, error.message, logger);
+    }
+    return errorResponse(500, 'server error', logger);
   }
 }
 

--- a/actions/pdp-renderer/render.js
+++ b/actions/pdp-renderer/render.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const { findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceString, getImageList } = require('./lib');
+const { generateLdJson } = require('./ldJson');
+const { requestSaaS } = require('../utils');
+const { ProductQuery, ProductByUrlKeyQuery } = require('../queries');
+
+function toTemplateProductData(baseProduct) {
+  const templateProductData = { ...baseProduct };
+  const primaryImage = getPrimaryImage(baseProduct)?.url;
+
+  templateProductData.hasImages = baseProduct.images?.length > 0;
+  templateProductData.imageList = getImageList(primaryImage, baseProduct.images);
+  templateProductData.priceString = generatePriceString(baseProduct);
+  templateProductData.metaDescription = findDescription(baseProduct);
+  templateProductData.metaImage = primaryImage;
+  templateProductData.primaryImage = primaryImage;
+  templateProductData.metaTitle = baseProduct.metaTitle || baseProduct.name || 'Product Details';
+
+  return templateProductData;
+}
+
+async function generateProductHtml(sku, urlKey, context) {
+  if (!sku && !urlKey) {
+    const error = new Error('Either sku or urlKey must be provided');
+    error.statusCode = 404;
+    throw error;
+  }
+  const logger = context.logger;
+  let baseProduct;
+  if (sku) {
+    const baseProductData = await requestSaaS(ProductQuery, 'ProductQuery', { sku: sku.toUpperCase() }, context);
+    if (!baseProductData?.data?.products || baseProductData?.data?.products?.length === 0) {
+      const error = new Error('Product not found');
+      error.statusCode = 404;
+      throw error;
+    }
+    baseProduct = baseProductData.data.products[0];
+  } else if (urlKey) {
+    const baseProductData = await requestSaaS(ProductByUrlKeyQuery, 'ProductByUrlKey', { urlKey }, context);
+    if (!baseProductData?.data?.productSearch || baseProductData?.data?.productSearch?.items?.length === 0) {
+      const error = new Error('Product not found');
+      error.statusCode = 404;
+      throw error;
+    }
+    baseProduct = baseProductData.data.productSearch.items[0].productView;
+  }
+  logger.debug('Retrieved base product', JSON.stringify(baseProduct, null, 4));
+
+  // Assign meta tag data for template
+  const templateProductData = toTemplateProductData(baseProduct);
+
+  // Generate LD-JSON
+  const ldJson = await generateLdJson(baseProduct, context);
+
+  // Load the Handlebars template
+  const [pageHbs, headHbs, productDetailsHbs] = ['page', 'head', 'product-details'].map((template) => fs.readFileSync(path.join(__dirname, 'templates', `${template}.hbs`), 'utf8'));
+  const pageTemplate = Handlebars.compile(pageHbs);
+  Handlebars.registerPartial('head', headHbs);
+  Handlebars.registerPartial('product-details', productDetailsHbs);
+
+  if (context.productsTemplate) {
+    // Retrieve default product page as template
+    const blocksToReplace = ['product-details'];
+    const baseTemplate = await prepareBaseTemplate(context.productsTemplate, blocksToReplace);
+    Handlebars.registerPartial('content', baseTemplate);
+  } else {
+    // Use product details block as sole content if no products template is defined
+    Handlebars.registerPartial('content', productDetailsHbs);
+  }
+
+  return pageTemplate({
+    ...templateProductData,
+    ldJson,
+  });
+}
+
+module.exports = {
+  generateProductHtml,
+};

--- a/app.config.yaml
+++ b/app.config.yaml
@@ -6,11 +6,11 @@ application:
         license: Apache-2.0
         inputs:
           LOG_LEVEL: debug
-          HLX_CONTENT_URL: "https://main--aem-boilerplate-commerce--hlxsites.aem.live"
-          HLX_PRODUCTS_TEMPLATE: "https://main--aem-boilerplate-commerce--hlxsites.aem.live/products/default"
-          HLX_ORG_NAME: "hlxsites"
-          HLX_SITE_NAME: "aem-boilerplate-commerce"
-          HLX_STORE_URL: "https://www.aemshop.net"
+          HLX_CONTENT_URL: "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live"
+          HLX_PRODUCTS_TEMPLATE: "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/default"
+          HLX_ORG_NAME: "adobe-rnd"
+          HLX_SITE_NAME: "aem-commerce-ssg-storefront"
+          HLX_STORE_URL: "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live"
           HLX_CONFIG_NAME: "configs"
           HLX_PATH_FORMAT: "/products/{urlKey}/{sku}"
           # HLX_LOCALES: comma-seprated list of allowed locales.
@@ -22,7 +22,7 @@ application:
           pdp-renderer:
             function: actions/pdp-renderer/index.js
             web: 'yes'
-            runtime: nodejs:18
+            runtime: nodejs:22
             annotations:
               final: true
             include:

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -24,15 +24,15 @@ const EXAMPLE_EXPECTED_STATE = {
   locale: 'uk',
   skus: {
     sku1: {
-      time: new Date(1),
+      lastPreviewedAt: new Date(1),
       hash: '',
     },
     sku2: {
-      time: new Date(2),
+      lastPreviewedAt: new Date(2),
       hash: '',
     },
     sku3: {
-      time: new Date(3),
+      lastPreviewedAt: new Date(3),
       hash: '',
     },
   },
@@ -58,15 +58,94 @@ jest.spyOn(AdminAPI.prototype, 'previewAndPublish').mockImplementation(({ sku })
   });
 });
 
+jest.mock('../actions/pdp-renderer/render', () => ({
+  generateProductHtml: jest.fn().mockImplementation((sku) => {
+    if (sku === 'sku-123') return '<html>Product 123</html>';
+    if (sku === 'sku-456') return '<html>Product 456</html>';
+    if (sku === 'sku-789') return '<html>Product 789</html>';
+    if (sku === 'sku-failed-due-preview') return '<html>Failed Preview</html>';
+    if (sku === 'sku-failed-due-publishing') return '<html>Failed Publishing</html>';
+    return `<html>Product ${sku}</html>`;
+  }),
+}));
+
+// Add mock for crypto to return predictable hashes
+jest.mock('crypto', () => {
+  const originalModule = jest.requireActual('crypto');
+  return {
+    ...originalModule,
+    createHash: jest.fn().mockImplementation(() => {
+      return {
+        update: jest.fn().mockImplementation((content) => {
+          return {
+            digest: jest.fn().mockImplementation(() => {
+              if (content === '<html>Product 123</html>') return 'current-hash-for-product-123';
+              if (content === '<html>Product 456</html>') return 'current-hash-for-product-456';
+              if (content === '<html>Product 789</html>') return 'current-hash-for-product-789';
+              return 'default-hash';
+            })
+          };
+        })
+      };
+    })
+  };
+});
+
 describe('Poller', () => {
-  const filesLibMock = {
+  // Common test fixtures
+  const mockFiles = () => ({
     read: jest.fn().mockResolvedValue(null),
     write: jest.fn().mockResolvedValue(null),
-  };
+  });
 
-  const stateLibMock = {
+  const mockState = () => ({
     get: jest.fn().mockResolvedValue(null),
     put: jest.fn().mockResolvedValue(null),
+  });
+
+  const defaultParams = {
+    HLX_SITE_NAME: 'siteName',
+    HLX_PATH_FORMAT: 'pathFormat',
+    PLPURIPrefix: 'prefix',
+    HLX_ORG_NAME: 'orgName',
+    HLX_CONFIG_NAME: 'configName',
+    authToken: 'token',
+    skusRefreshInterval: 600000,
+  };
+
+  const setupSkuData = (filesLib, stateLib, skuData, lastQueriedAt) => {
+    const skuEntries = Object.entries(skuData).map(([sku, { timestamp, hash = '' }]) => 
+      `${sku},${timestamp},${hash}`
+    ).join('\n');
+    
+    filesLib.read.mockResolvedValueOnce(skuEntries);
+    stateLib.get.mockResolvedValueOnce({ value: lastQueriedAt });
+  };
+
+  const mockSaaSResponse = (skus, lastModifiedOffset = 10000) => {
+    requestSaaS.mockImplementation((query, operation) => {
+      if (operation === 'getAllSkus') {
+        return Promise.resolve({
+          data: {
+            productSearch: {
+              items: skus.map(sku => ({ productView: sku }))
+            }
+          },
+        });
+      }
+      if (operation === 'getLastModified') {
+        return Promise.resolve({
+          data: {
+            products: skus.map(sku => ({ 
+              urlKey: `url-${sku}`, 
+              sku, 
+              lastModifiedAt: new Date().getTime() - lastModifiedOffset 
+            })),
+          },
+        });
+      }
+      return Promise.resolve({});
+    });
   };
 
   afterEach(() => {
@@ -105,11 +184,11 @@ describe('Poller', () => {
     assert.deepEqual(state, EXAMPLE_EXPECTED_STATE);
     state.skusLastQueriedAt = new Date(4);
     state.skus['sku1'] = {
-      time: new Date(4),
+      lastPreviewedAt: new Date(4),
       hash: 'hash1',
     };
     state.skus['sku2'] = {
-      time: new Date(5),
+      lastPreviewedAt: new Date(5),
       hash: 'hash2',
     };
     await saveState(state, { filesLib, stateLib });
@@ -136,11 +215,11 @@ describe('Poller', () => {
     assert.deepEqual(state, expectedState);
     state.skusLastQueriedAt = new Date(4);
     state.skus['sku1'] = {
-      time: new Date(4),
+      lastPreviewedAt: new Date(4),
       hash: 'hash1',
     };
     state.skus['sku2'] = {
-      time: new Date(5),
+      lastPreviewedAt: new Date(5),
       hash: 'hash2',
     };
     await saveState(state, { filesLib, stateLib });
@@ -151,232 +230,240 @@ describe('Poller', () => {
     assert.equal(skusLastQueriedAt.value, "4");
   });
 
-  it('checkParams should throw an error if required parameters are missing', async () => {
-    const params = {
-      HLX_SITE_NAME: 'siteName',
-      HLX_PATH_FORMAT: 'pathFormat',
-      PLPURIPrefix: 'prefix',
-      HLX_ORG_NAME: 'orgName',
-      // HLX_CONFIG_NAME is missing
-      authToken: 'token',
-    };
+  describe('Parameter validation', () => {
+    it('should throw an error if required parameters are missing', async () => {
+      const params = { ...defaultParams };
+      delete params.HLX_CONFIG_NAME;
+      
+      const filesLib = mockFiles();
+      const stateLib = mockState();
 
-    await expect(poll(params, { filesLib: filesLibMock, stateLib: stateLibMock })).rejects.toThrow('Missing required parameters: HLX_CONFIG_NAME');
-  });
-
-  it('checkParams should throw an error if HLX_STORE_URL is invalid', async () => {
-    isValidUrl.mockReturnValue(false);
-    const params = {
-      HLX_SITE_NAME: 'siteName',
-      HLX_PATH_FORMAT: 'pathFormat',
-      PLPURIPrefix: 'prefix',
-      HLX_ORG_NAME: 'orgName',
-      HLX_CONFIG_NAME: 'configName',
-      authToken: 'token',
-      HLX_STORE_URL: 'invalid-url',
-    };
-
-    await expect(poll(params, { filesLib: filesLibMock, stateLib: stateLibMock })).rejects.toThrow('Invalid storeUrl');
-  });
-
-  it('Poller should fetch and process SKU updates and 2 sku failed', async () => {
-    const params = {
-      HLX_SITE_NAME: 'siteName',
-      HLX_PATH_FORMAT: 'pathFormat',
-      PLPURIPrefix: 'prefix',
-      HLX_ORG_NAME: 'orgName',
-      HLX_CONFIG_NAME: 'configName',
-      authToken: 'token',
-      skusRefreshInterval: 600000,
-    };
-
-    requestSaaS.mockImplementation((query, operation) => {
-      if (operation === 'getAllSkus') {
-        return Promise.resolve({
-          data: {
-            productSearch: {
-              items: [
-                { productView: 'sku-123' },
-                { productView: 'sku-456' },
-                { productView: 'sku-failed-due-preview' },
-                { productView: 'sku-failed-due-publishing' }
-              ]
-            }
-          },
-        });
-      }
-      if (operation === 'getLastModified') {
-        return Promise.resolve({
-          data: {
-            products: [
-              { urlKey: 'url-sku-123', sku: 'sku-123', lastModifiedAt: new Date().getTime() - 5000 },
-              { urlKey: 'url-sku-456', sku: 'sku-456', lastModifiedAt: new Date().getTime() - 10000 },
-              { urlKey: 'url-failed-due-preview', sku: 'sku-failed-due-preview', lastModifiedAt: new Date().getTime() - 20000 },
-              { urlKey: 'url-failed-due-publishing', sku: 'sku-failed-due-publishing', lastModifiedAt: new Date().getTime() - 20000 },
-            ],
-          },
-        });
-      }
-      return Promise.resolve({});
+      await expect(poll(params, { filesLib, stateLib }))
+        .rejects.toThrow('Missing required parameters: HLX_CONFIG_NAME');
     });
 
-    const result = await poll(params, { filesLib: filesLibMock, stateLib: stateLibMock });
+    it('should throw an error if HLX_STORE_URL is invalid', async () => {
+      isValidUrl.mockReturnValue(false);
+      const params = {
+        ...defaultParams,
+        HLX_STORE_URL: 'invalid-url',
+      };
+      
+      const filesLib = mockFiles();
+      const stateLib = mockState();
 
-    expect(result.state).toBe('completed');
-    expect(result.status.published).toBe(2);
-    expect(result.status.failed).toBe(2);
-    expect(result.status.unpublished).toBe(0);
-    expect(result.status.ignored).toBe(0);
-
-    expect(requestSaaS).toBeCalledTimes(2);
-    expect(requestSaaS).toHaveBeenNthCalledWith(
-        1,
-        GetAllSkusQuery,
-        'getAllSkus',
-        {},
-        expect.anything()
-    );
-    expect(requestSaaS).toHaveBeenNthCalledWith(
-        2,
-        expect.anything(),
-        'getLastModified',
-        expect.objectContaining({
-          skus: expect.arrayContaining(['sku-123', 'sku-456']),
-        }),
-        expect.anything()
-    );
-    expect(filesLibMock.read).toHaveBeenCalled();
-    expect(stateLibMock.get).toHaveBeenCalled();
-    expect(filesLibMock.write).toHaveBeenCalled();
-    expect(stateLibMock.put).toHaveBeenCalled();
-    expect(AdminAPI.prototype.startProcessing).toHaveBeenCalledTimes(1);
-    expect(AdminAPI.prototype.stopProcessing).toHaveBeenCalledTimes(1);
-    expect(AdminAPI.prototype.previewAndPublish).toHaveBeenCalled();
-    expect(AdminAPI.prototype.unpublishAndDelete).not.toHaveBeenCalled();
+      await expect(poll(params, { filesLib, stateLib }))
+        .rejects.toThrow('Invalid storeUrl');
+    });
   });
 
-  it('Poller should not fetch SKU and not process them', async () => {
-    filesLibMock.read.mockImplementationOnce(() => {
+  describe('Product processing', () => {
+    it('should process products with changed content and update hashes', async () => {
       const now = new Date().getTime();
-      return Promise.resolve(
-          `sku-123,${now - 10000},\nsku-456,${now - 10000},\nsku-789,${now - 10000},`
+      const filesLib = mockFiles();
+      const stateLib = mockState();
+      
+      // Setup initial state with existing products
+      setupSkuData(
+        filesLib, 
+        stateLib, 
+        {
+          'sku-123': { timestamp: now - 100000, hash: 'old-hash-for-product-123' }
+        }, 
+        now - 700000
       );
-    });
-    const stateLib = new MockState(0);
-    await stateLib.put('default.skusLastQueriedAt', new Date().getTime().toString());
+      
+      // Mock catalog service responses
+      mockSaaSResponse(['sku-123'], 5000);
+      
+      const result = await poll(defaultParams, { filesLib, stateLib });
 
-    const params = {
-      HLX_SITE_NAME: 'siteName',
-      HLX_PATH_FORMAT: 'pathFormat',
-      PLPURIPrefix: 'prefix',
-      HLX_ORG_NAME: 'orgName',
-      HLX_CONFIG_NAME: 'configName',
-      authToken: 'token',
-      skusRefreshInterval: 600000,
-    };
-
-    requestSaaS.mockImplementation((query, operation) => {
-      if (operation === 'getLastModified') {
-        return Promise.resolve({
-          data: {
-            products: [
-              { urlKey: 'url-sku-123', sku: 'sku-123', lastModifiedAt: new Date().getTime() - 20000 },
-              { urlKey: 'url-sku-456', sku: 'sku-456', lastModifiedAt: new Date().getTime() - 30000 },
-              { urlKey: null, sku: 'sku-789', lastModifiedAt: new Date().getTime() - 5000 },
-            ],
-          },
-        });
-      }
-      return Promise.resolve({});
+      // Verify results
+      expect(result.state).toBe('completed');
+      expect(result.status.published).toBe(1);
+      expect(result.status.ignored).toBe(0);
+      
+      // Verify hash was updated
+      expect(filesLib.write).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('current-hash-for-product-123')
+      );
+      
+      // Verify API calls
+      expect(AdminAPI.prototype.previewAndPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ sku: 'sku-123' })
+      );
+      expect(AdminAPI.prototype.startProcessing).toHaveBeenCalledTimes(1);
+      expect(AdminAPI.prototype.stopProcessing).toHaveBeenCalledTimes(1);
     });
 
-    const result = await poll(params, { filesLib: filesLibMock, stateLib });
+    it('should ignore products with unchanged content', async () => {
+      const now = new Date().getTime();
+      const filesLib = mockFiles();
+      const stateLib = mockState();
+      
+      // Setup initial state with existing products that have current hash
+      setupSkuData(
+        filesLib, 
+        stateLib, 
+        {
+          'sku-456': { timestamp: now - 10000, hash: 'current-hash-for-product-456' }
+        }, 
+        now - 700000
+      );
+      
+      // Mock catalog service responses
+      mockSaaSResponse(['sku-456'], 5000);
+      
+      const result = await poll(defaultParams, { filesLib, stateLib });
 
-    expect(result.state).toBe('completed');
-    expect(result.status.published).toBe(0);
-    expect(result.status.failed).toBe(0);
-    expect(result.status.unpublished).toBe(0);
-    expect(result.status.ignored).toBe(3);
+      // Verify results
+      expect(result.state).toBe('completed');
+      expect(result.status.published).toBe(0);
+      expect(result.status.ignored).toBe(1);
+      
+      // Verify no preview/publish was called
+      expect(AdminAPI.prototype.previewAndPublish).not.toHaveBeenCalled();
+    });
 
-    expect(requestSaaS).toBeCalledTimes(1);
-    expect(requestSaaS).toHaveBeenNthCalledWith(
-        1,
-        expect.anything(),
-        'getLastModified',
-        expect.objectContaining({
-          skus: expect.arrayContaining(['sku-123', 'sku-456']),
-        }),
-        expect.anything()
-    );
-    expect(filesLibMock.read).toHaveBeenCalled();
-    expect(filesLibMock.write).not.toHaveBeenCalled();
-    expect(AdminAPI.prototype.startProcessing).toHaveBeenCalledTimes(1);
-    expect(AdminAPI.prototype.stopProcessing).toHaveBeenCalledTimes(1);
-    expect(AdminAPI.prototype.previewAndPublish).not.toHaveBeenCalled();
-    expect(AdminAPI.prototype.unpublishAndDelete).not.toHaveBeenCalled();
+    it('should handle failed preview and publishing', async () => {
+      const now = new Date().getTime();
+      const filesLib = mockFiles();
+      const stateLib = mockState();
+      
+      // Setup initial state with existing products
+      setupSkuData(
+        filesLib, 
+        stateLib, 
+        {
+          'sku-failed-due-preview': { timestamp: now - 100000 },
+          'sku-failed-due-publishing': { timestamp: now - 100000 }
+        }, 
+        now - 700000
+      );
+      
+      // Mock catalog service responses
+      mockSaaSResponse(['sku-failed-due-preview', 'sku-failed-due-publishing'], 20000);
+      
+      const result = await poll(defaultParams, { filesLib, stateLib });
+
+      // Verify results
+      expect(result.state).toBe('completed');
+      expect(result.status.published).toBe(0);
+      expect(result.status.failed).toBe(2);
+      
+      // Verify API calls
+      expect(AdminAPI.prototype.previewAndPublish).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not process products when they are not modified', async () => {
+      const now = new Date().getTime();
+      const filesLib = mockFiles();
+      const stateLib = mockState();
+      
+      // Setup initial state with recently processed products
+      setupSkuData(
+        filesLib, 
+        stateLib, 
+        {
+          'sku-123': { timestamp: now - 10000 },
+          'sku-456': { timestamp: now - 10000 },
+          'sku-789': { timestamp: now - 10000 }
+        }, 
+        now - 100000 // Recent query time
+      );
+      
+      // Mock catalog service responses with older modification times
+      requestSaaS.mockImplementation((query, operation) => {
+        if (operation === 'getLastModified') {
+          return Promise.resolve({
+            data: {
+              products: [
+                { urlKey: 'url-sku-123', sku: 'sku-123', lastModifiedAt: now - 20000 },
+                { urlKey: 'url-sku-456', sku: 'sku-456', lastModifiedAt: now - 30000 },
+                { urlKey: null, sku: 'sku-789', lastModifiedAt: now - 5000 },
+              ],
+            },
+          });
+        }
+        return Promise.resolve({});
+      });
+      
+      const result = await poll(defaultParams, { filesLib, stateLib });
+
+      // Verify results
+      expect(result.state).toBe('completed');
+      expect(result.status.published).toBe(0);
+      expect(result.status.ignored).toBe(3);
+      
+      // Verify no processing occurred
+      expect(AdminAPI.prototype.previewAndPublish).not.toHaveBeenCalled();
+      expect(filesLib.write).not.toHaveBeenCalled();
+    });
   });
 
-  it('Poller should delete SKUs that are not in the catalog service, one of them is failed', async () => {
-    const params = {
-      HLX_SITE_NAME: 'siteName',
-      HLX_PATH_FORMAT: 'pathFormat',
-      PLPURIPrefix: 'prefix',
-      HLX_ORG_NAME: 'orgName',
-      HLX_CONFIG_NAME: 'configName',
-      authToken: 'token',
-      skusRefreshInterval: 600000,
-    };
-
-    filesLibMock.read.mockImplementationOnce(() => {
+  describe('Product unpublishing', () => {
+    it('should unpublish products that are not in the catalog', async () => {
       const now = new Date().getTime();
-      return Promise.resolve(
-          `sku-123,${now - 10000},\nsku-456,${now - 10000},\nsku-failed,${now - 10000},`
+      const filesLib = mockFiles();
+      const stateLib = mockState();
+      
+      // Setup initial state with products that will be partially removed
+      setupSkuData(
+        filesLib, 
+        stateLib, 
+        {
+          'sku-123': { timestamp: now - 10000 },
+          'sku-456': { timestamp: now - 10000 },
+          'sku-failed': { timestamp: now - 10000 }
+        }, 
+        now - 100000
       );
-    });
-    const stateLib = new MockState(0);
-    await stateLib.put('default.skusLastQueriedAt', new Date().getTime().toString());
-
-    requestSaaS.mockImplementation((query, operation) => {
-      if (operation === 'getLastModified') {
+      
+      // Mock catalog service to only return one product
+      requestSaaS.mockImplementation((query, operation) => {
+        if (operation === 'getLastModified') {
+          return Promise.resolve({
+            data: {
+              products: [
+                { urlKey: 'url-sku-123', sku: 'sku-123', lastModifiedAt: now - 20000 },
+              ],
+            },
+          });
+        }
+        return Promise.resolve({});
+      });
+      
+      // Mock spreadsheet response for products to be removed
+      requestSpreadsheet.mockImplementation(() => {
         return Promise.resolve({
-          data: {
-            products: [
-              { urlKey: 'url-sku-123', sku: 'sku-123', lastModifiedAt: new Date().getTime() - 20000 },
-            ],
-          },
+          data: [
+            { sku: 'sku-456' },
+            { sku: 'sku-failed' },
+          ],
         });
-      }
-      return Promise.resolve({});
-    });
-
-    requestSpreadsheet.mockImplementation(() => {
-      return Promise.resolve({
-        data: [
-          { sku: 'sku-456' },
-          { sku: 'sku-failed' },
-        ],
       });
-    });
-
-    AdminAPI.prototype.unpublishAndDelete.mockImplementation(({ sku }) => {
-      return Promise.resolve({ 
-        sku,
-        deletedAt: sku === 'sku-failed' ? null : new Date() 
+      
+      // Mock unpublish with one success and one failure
+      AdminAPI.prototype.unpublishAndDelete.mockImplementation(({ sku }) => {
+        return Promise.resolve({ 
+          sku,
+          deletedAt: sku === 'sku-failed' ? null : new Date() 
+        });
       });
+      
+      const result = await poll(defaultParams, { filesLib, stateLib });
+
+      // Verify results
+      expect(result.state).toBe('completed');
+      expect(result.status.published).toBe(0);
+      expect(result.status.unpublished).toBe(1);
+      expect(result.status.failed).toBe(1);
+      expect(result.status.ignored).toBe(1);
+      
+      // Verify API calls
+      expect(AdminAPI.prototype.unpublishAndDelete).toHaveBeenCalledTimes(2);
+      expect(filesLib.write).toHaveBeenCalled();
     });
-
-    const result = await poll(params, { filesLib: filesLibMock, stateLib });
-
-    expect(result.state).toBe('completed');
-    expect(result.status.published).toBe(0);
-    expect(result.status.failed).toBe(1);
-    expect(result.status.unpublished).toBe(1);
-    expect(result.status.ignored).toBe(1);
-
-    expect(requestSaaS).toBeCalledTimes(1);
-    expect(requestSpreadsheet).toBeCalledTimes(1);
-    expect(AdminAPI.prototype.unpublishAndDelete).toBeCalledTimes(2);
-    expect(filesLibMock.read).toHaveBeenCalled();
-    expect(filesLibMock.write).toHaveBeenCalled();
   });
 });

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -15,7 +15,6 @@ const { loadState, saveState, getStateFileLocation, poll } = require('../actions
 const Files = require('./__mocks__/files.js');
 const { AdminAPI } = require('../actions/check-product-changes/lib/aem');
 const { requestSaaS, requestSpreadsheet, isValidUrl} = require('../actions/utils');
-const { GetAllSkusQuery } = require('../actions/queries');
 const { MockState } = require('./__mocks__/state.js');
 
 const EXAMPLE_STATE = 'sku1,1,\nsku2,2,\nsku3,3,';

--- a/test/mock-server.js
+++ b/test/mock-server.js
@@ -42,6 +42,10 @@ const handlers = {
     matcher?.(req);
     return HttpResponse.json({ data: { products: [] }});
   }),
+  returnLiveSearch404: (matcher) => graphql.query('ProductByUrlKey', (req) => {
+    matcher?.(req);
+    return HttpResponse.json({ data: { productSearch: { items: [] } }});
+  }),
   defaultProductTemplate : http.get('https://content.com/products/default.plain.html', () => {
     return HttpResponse.html(mockProductTemplate);
   }),


### PR DESCRIPTION
Current implementation: products are previewed and published based on comparing last preview time and last modified time of each product. That is often too greedy as no re-preview is needed unless the real HTML output changes.

New implementation: the poller will generate a hash from the HTML output of the currently published page (or more precisely, its HTML markup generated by the overlay) and save it in the state storage. When the poller executes next time, it will generate a new hash based on the new HTML output, compare it with the stored hash. If equals, it will ignore the product from preview / publish. If different, it will process it.

As mentioned in #33 , the format of the poller state is now:
```
sku1,timestamp,hash
sku2,timestamp,hash
sku3,timestamp,hash
```