### PR TITLE
store HTML markup in lib files public

### DIFF
--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -24,15 +24,10 @@ function getStateFileLocation(stateKey) {
   return `${FILE_PREFIX}/${stateKey}.${FILE_EXT}`;
 }
 
-function getSkusLastQueriedStateKey(stateKey) {
-  return `${stateKey}.skusLastQueriedAt`;
-}
-
 /**
  * @typedef {Object} PollerState
  * @property {string} locale - The locale (or store code).
- * @property {Array<String>} skus - The SKUs to be saved.
- * @property {Date} skusLastQueriedAt - Last time when the SKUs have been queried.
+ * @property {Array<Object>} skus - The SKUs with last previewed timestamp and hash.
  */
 
 /**
@@ -49,15 +44,10 @@ function getSkusLastQueriedStateKey(stateKey) {
  * @returns {Promise<PollerState>} - A promise that resolves when the state is loaded, returning the state object.
  */
 async function loadState(locale, aioLibs) {
-  const { filesLib, stateLib } = aioLibs;
+  const { filesLib } = aioLibs;
   const stateObj = { locale };
   try {
     const stateKey = locale || 'default';
-    stateObj.skusLastQueriedAt = new Date(0);
-    const skusLastQueriedState = await stateLib.get(getSkusLastQueriedStateKey(stateKey));
-    if (skusLastQueriedState && skusLastQueriedState.value) {
-      stateObj.skusLastQueriedAt = new Date(parseInt(skusLastQueriedState.value));
-    }
     const fileLocation = getStateFileLocation(stateKey);
     const buffer = await filesLib.read(fileLocation);
     const stateData = buffer?.toString();
@@ -93,10 +83,9 @@ async function loadState(locale, aioLibs) {
  * @returns {Promise<void>} - A promise that resolves when the state is saved.
  */
 async function saveState(state, aioLibs) {
-  const { filesLib, stateLib } = aioLibs;
+  const { filesLib } = aioLibs;
   let { locale } = state;
   const stateKey = locale || 'default';
-  await stateLib.put(getSkusLastQueriedStateKey(stateKey), state.skusLastQueriedAt.getTime().toString());
   const fileLocation = getStateFileLocation(stateKey);
   const csvData = [
     ...Object.entries(state.skus)
@@ -206,7 +195,7 @@ function unpublishAndDelete(batches, locale, adminApi) {
 /**
  * Checks if a product should be processed
  * @param product
- * @returns {*|boolean}
+ * @returns {boolean}
  */
 function shouldProcessProduct(product) {
   const { urlKey, lastModifiedDate, lastPreviewDate, currentHash, newHash } = product;
@@ -217,6 +206,7 @@ function shouldProcessProduct(product) {
  * Processes a product to determine if it needs to be updated
  * @param {Object} product - The product to process
  * @param {Object} state - The current state
+ * @param {Object} context - The context object with logger and other utilities
  * @returns {Object} Enhanced product with additional metadata
  */
 async function enrichProductWithMetadata(product, state, context) {
@@ -225,20 +215,48 @@ async function enrichProductWithMetadata(product, state, context) {
   const lastPreviewDate = state.skus[sku]?.lastPreviewedAt || new Date(0);
   const lastModifiedDate = new Date(lastModifiedAt);
   let newHash = null;
+  let productHtml = null;
+  
   try {
-    const productHtml = await generateProductHtml(sku, urlKey, context);
+    productHtml = await generateProductHtml(sku, urlKey, context);
     newHash = crypto.createHash('sha256').update(productHtml).digest('hex');
+    
+    // Create enriched product object
+    const enrichedProduct = {
+      ...product,
+      lastModifiedDate,
+      lastPreviewDate,
+      currentHash: state.skus[sku]?.hash || null,
+      newHash,
+      productHtml
+    };
+    
+    // Save HTML immediately if product should be processed
+    if (shouldProcessProduct(enrichedProduct) && productHtml) {
+      try {
+        const { filesLib } = context.aioLibs;
+        const productUrl = getProductUrl({ urlKey, sku }, context, false).toLowerCase();
+        const htmlPath = `/public/pdps${productUrl}`;
+        await filesLib.write(htmlPath, productHtml);
+        logger.debug(`Saved HTML for product ${sku} to ${htmlPath}`);
+      } catch (e) {
+        logger.error(`Error saving HTML for product ${sku}:`, e);
+      }
+    }
+    
+    return enrichedProduct;
   } catch (e) {
     logger.error(`Error generating product HTML for SKU ${sku}:`, e);
+    // Return product with metadata even if HTML generation fails
+    return {
+      ...product,
+      lastModifiedDate,
+      lastPreviewDate,
+      currentHash: state.skus[sku]?.hash || null,
+      newHash: null,
+      productHtml: null
+    };
   }
-
-  return {
-    ...product,
-    lastModifiedDate,
-    lastPreviewDate,
-    currentHash: state.skus[sku]?.hash || null,
-    newHash
-  };
 }
 
 /**
@@ -270,6 +288,7 @@ async function processDeletedProducts(remainingSkus, locale, state, counts, cont
   if (!remainingSkus.length) return;
 
   try {
+    const { filesLib } = aioLibs;
     const publishedProducts = await requestSpreadsheet('published-products-index', null, context);
     const deletedProducts = publishedProducts.data.filter(({ sku }) => remainingSkus.includes(sku));
 
@@ -283,6 +302,19 @@ async function processDeletedProducts(remainingSkus, locale, state, counts, cont
       for (const { records, liveUnpublishedAt, previewUnpublishedAt } of response) {
         if (liveUnpublishedAt && previewUnpublishedAt) {
           records.map((record) => {
+            // Delete the HTML file from public storage
+            try {
+              const product = deletedProducts.find(p => p.sku === record.sku);
+              if (product) {
+                const productUrl = getProductUrl({ urlKey: product.urlKey, sku: product.sku }, context, false).toLowerCase();
+                const htmlPath = `/public/pdps${productUrl}`;
+                filesLib.delete(htmlPath);
+                logger.debug(`Deleted HTML file for product ${record.sku} from ${htmlPath}`);
+              }
+            } catch (e) {
+              logger.error(`Error deleting HTML file for product ${record.sku}:`, e);
+            }
+            
             delete state.skus[record.sku];
             counts.unpublished++;
           });
@@ -318,7 +350,7 @@ async function poll(params, aioLibs) {
     published: 0, unpublished: 0, ignored: 0, failed: 0,
   };
   const sharedContext = {
-    storeUrl, contentUrl, configName, logger, counts, pathFormat, productsTemplate
+    storeUrl, contentUrl, configName, logger, counts, pathFormat, productsTemplate, aioLibs
   };
   const timings = new Timings();
   const adminApi = new AdminAPI({
@@ -344,26 +376,20 @@ async function poll(params, aioLibs) {
         context = { ...context, ...mapLocale(locale, context) };
       }
 
-      // Refresh SKUs if needed
-      if (timings.now - state.skusLastQueriedAt >= skusRefreshInterval) {
-        state.skusLastQueriedAt = new Date();
+      const { filesLib } = aioLibs;
+      const productsFileName = getStateFileLocation(`${locale || 'default'}-products`);
+      const allskuBuffer = await filesLib.read(productsFileName);
+      const allSkusString = allskuBuffer.toString();
+      let allSkus = JSON.parse(allSkusString);
+      console.log(allSkus);
 
-        const { filesLib } = aioLibs;
-        const productsFileName = getStateFileLocation(`${locale || 'default'}-products`);
-        const allskuBuffer = await filesLib.read(productsFileName);
-        const allSkusString = allskuBuffer.toString();
-        let allSkus = JSON.parse(allSkusString);
-
-        // add new skus to state if any
-        for (const sku of allSkus) {
-          if (!state.skus[sku.sku]) {
-            state.skus[sku.sku] = { lastPreviewedAt: new Date(0), hash: null };
-          }
+      // add new skus to state if any
+      for (const sku of allSkus) {
+        if (!state.skus[sku.sku]) {
+          state.skus[sku.sku] = { lastPreviewedAt: new Date(0), hash: null };
         }
-        timings.sample('fetchedSkus');
-      } else {
-        timings.sample('fetchedSkus', 0);
       }
+      timings.sample('fetchedSkus');
 
       // get last modified dates
       const skus = Object.keys(state.skus);

--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -121,7 +121,6 @@ async function deleteState(locale, filesLib) {
  * @param {string} params.HLX_CONFIG_NAME - The name of the configuration json/xlsx.
  * @param {string} params.HLX_PRODUCTS_TEMPLATE URL to the products template page
  * @param {string} params.authToken - The authentication token.
- * @param {number} [params.skusRefreshInterval=600000] - The interval for refreshing SKUs in milliseconds.
  * @param {string} [params.HLX_STORE_URL] - The store's base URL.
  * @param {string} [params.HLX_LOCALES] - Comma-separated list of allowed locales.
  * @param {string} [params.LOG_LEVEL] - The log level.
@@ -340,7 +339,6 @@ async function poll(params, aioLibs) {
     HLX_CONFIG_NAME: configName,
     HLX_PRODUCTS_TEMPLATE: productsTemplate,
     authToken,
-    skusRefreshInterval = 600000,
   } = params;
   const storeUrl = params.HLX_STORE_URL ? params.HLX_STORE_URL : `https://main--${siteName}--${orgName}.aem.live`;
   const contentUrl = params.HLX_CONTENT_URL ? params.HLX_CONTENT_URL : `https://main--${siteName}--${orgName}.aem.live`;

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -35,14 +35,13 @@ const EXAMPLE_EXPECTED_STATE = {
       hash: '',
     },
   },
-  skusLastQueriedAt: new Date(1),
 };
 
 jest.mock('../actions/utils', () => ({
   requestSaaS: jest.fn(),
   requestSpreadsheet: jest.fn(),
   isValidUrl: jest.fn(() => true),
-  getProductUrl: jest.fn(({ urlKey, sku }) => `https://store.com/${urlKey || sku}`),
+  getProductUrl: jest.fn(({ urlKey, sku }) => `/${urlKey || sku}`),
   mapLocale: jest.fn((locale) => ({ locale })),
 }));
 
@@ -95,6 +94,7 @@ describe('Poller', () => {
   const mockFiles = () => ({
     read: jest.fn().mockResolvedValue(null),
     write: jest.fn().mockResolvedValue(null),
+    delete: jest.fn().mockResolvedValue(null),
   });
 
   const mockState = () => ({
@@ -167,7 +167,6 @@ describe('Poller', () => {
       {
         locale: 'uk',
         skus: {},
-        skusLastQueriedAt: new Date(0),
       }
     );
   });
@@ -176,7 +175,6 @@ describe('Poller', () => {
     const filesLib = new Files(0);
     const stateLib = new MockState(0);
     await filesLib.write(getStateFileLocation('uk'), EXAMPLE_STATE);
-    await stateLib.put('uk.skusLastQueriedAt', 1);
     const state = await loadState('uk', { filesLib, stateLib });
     assert.deepEqual(state, EXAMPLE_EXPECTED_STATE);
   });
@@ -185,10 +183,8 @@ describe('Poller', () => {
     const filesLib = new Files(0);
     const stateLib = new MockState(0);
     await filesLib.write(getStateFileLocation('uk'), EXAMPLE_STATE);
-    await stateLib.put('uk.skusLastQueriedAt', 1);
     const state = await loadState('uk', { filesLib, stateLib });
     assert.deepEqual(state, EXAMPLE_EXPECTED_STATE);
-    state.skusLastQueriedAt = new Date(4);
     state.skus['sku1'] = {
       lastPreviewedAt: new Date(4),
       hash: 'hash1',
@@ -201,8 +197,6 @@ describe('Poller', () => {
 
     const serializedState = await filesLib.read(getStateFileLocation('uk'));
     assert.equal(serializedState, 'sku1,4,hash1\nsku2,5,hash2\nsku3,3,');
-    const skusLastQueriedAt = await stateLib.get('uk.skusLastQueriedAt');
-    assert.equal(skusLastQueriedAt.value, "4");
 
     const newState = await loadState('uk', { filesLib, stateLib });
     assert.deepEqual(newState, state);
@@ -212,14 +206,12 @@ describe('Poller', () => {
     const filesLib = new Files(0);
     const stateLib = new MockState(0);
     await filesLib.write(getStateFileLocation('default'), EXAMPLE_STATE);
-    await stateLib.put('default.skusLastQueriedAt', 1);
     const state = await loadState('default', { filesLib, stateLib });
     const expectedState = {
       ...EXAMPLE_EXPECTED_STATE,
       locale: 'default',
     };
     assert.deepEqual(state, expectedState);
-    state.skusLastQueriedAt = new Date(4);
     state.skus['sku1'] = {
       lastPreviewedAt: new Date(4),
       hash: 'hash1',
@@ -232,8 +224,6 @@ describe('Poller', () => {
 
     const serializedState = await filesLib.read(getStateFileLocation('default'));
     assert.equal(serializedState, 'sku1,4,hash1\nsku2,5,hash2\nsku3,3,');
-    const skusLastQueriedAt = await stateLib.get('default.skusLastQueriedAt');
-    assert.equal(skusLastQueriedAt.value, "4");
   });
 
   describe('Parameter validation', () => {
@@ -295,10 +285,16 @@ describe('Poller', () => {
           expect.stringContaining('current-hash-for-product-123')
       );
 
+      // Verify HTML file was saved
+      expect(filesLib.write).toHaveBeenCalledWith(
+        '/public/pdps/url-sku-123',
+        '<html>Product 123</html>'
+      );
+
       // Verify API calls
       expect(AdminAPI.prototype.previewAndPublish).toHaveBeenCalledWith(
           expect.arrayContaining([
-            expect.objectContaining({ path: 'https://store.com/url-sku-123', sku: 'sku-123' })
+            expect.objectContaining({ path: '/url-sku-123', sku: 'sku-123' })
           ]),
           null,
           1
@@ -475,6 +471,61 @@ describe('Poller', () => {
       // Verify API calls
       expect(AdminAPI.prototype.unpublishAndDelete).toHaveBeenCalledTimes(1);
       expect(filesLib.write).toHaveBeenCalled();
+    });
+
+    it('should delete HTML files when unpublishing products', async () => {
+      const now = new Date().getTime();
+      const filesLib = mockFiles();
+      const stateLib = mockState();
+
+      // Setup initial state with products that will be removed
+      setupSkuData(
+        filesLib,
+        stateLib,
+        {
+          'sku-123': { timestamp: now - 10000 },
+          'sku-456': { timestamp: now - 10000 }
+        },
+        now - 100000
+      );
+
+      // Mock catalog service to only return no products (all should be unpublished)
+      requestSaaS.mockImplementation((query, operation) => {
+        if (operation === 'getLastModified') {
+          return Promise.resolve({
+            data: {
+              products: [],
+            },
+          });
+        }
+        return Promise.resolve({});
+      });
+
+      // Mock spreadsheet response for products to be removed
+      requestSpreadsheet.mockImplementation(() => {
+        return Promise.resolve({
+          data: [
+            { sku: 'sku-123', urlKey: 'url-sku-123' },
+            { sku: 'sku-456', urlKey: 'url-sku-456' }
+          ],
+        });
+      });
+
+      // Mock successful unpublish
+      AdminAPI.prototype.unpublishAndDelete.mockImplementation((batch) => {
+        return Promise.resolve({
+          records: batch.map(({ sku }) => ({ sku })),
+          liveUnpublishedAt: new Date(),
+          previewUnpublishedAt: new Date(),
+        });
+      });
+
+      await poll(defaultParams, { filesLib, stateLib });
+
+      // Verify HTML files were deleted
+      expect(filesLib.delete).toHaveBeenCalledTimes(2);
+      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/url-sku-123');
+      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/url-sku-456');
     });
   });
 });

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -109,7 +109,6 @@ describe('Poller', () => {
     HLX_ORG_NAME: 'orgName',
     HLX_CONFIG_NAME: 'configName',
     authToken: 'token',
-    skusRefreshInterval: 600000,
   };
 
   const setupSkuData = (filesLib, stateLib, skuData, lastQueriedAt) => {


### PR DESCRIPTION
Currently, overlay URL in helix is configured to be the `pdp-renderer` web action URL, which renders the PDP HTML on the go.
When the HTML is compared between the new and old commerce data, the HTML output is anyway produced.
This PR makes the HTML files available in aio-lib-files public folder, which serves the overlay markup directly to Helix content bus..