### PR TITLE
fix: e2e tests, using file extension for html markup

### DIFF
--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -12,16 +12,15 @@ governing permissions and limitations under the License.
 
 const { Timings, aggregate } = require('../lib/benchmark');
 const { AdminAPI } = require('../lib/aem');
-const { requestSaaS, requestSpreadsheet, isValidUrl, getProductUrl, mapLocale } = require('../utils');
+const { requestSaaS, requestSpreadsheet, isValidUrl, getProductUrl, mapLocale, FILE_PREFIX, STATE_FILE_EXT, PDP_FILE_EXT } = require('../utils');
 const { GetLastModifiedQuery } = require('../queries');
 const { Core } = require('@adobe/aio-sdk');
 const { generateProductHtml } = require('../pdp-renderer/render');
 const crypto = require('crypto');
-const { FILE_PREFIX, FILE_EXT } = require('../utils');
 const BATCH_SIZE = 50;
 
 function getStateFileLocation(stateKey) {
-  return `${FILE_PREFIX}/${stateKey}.${FILE_EXT}`;
+  return `${FILE_PREFIX}/${stateKey}.${STATE_FILE_EXT}`;
 }
 
 /**
@@ -235,7 +234,7 @@ async function enrichProductWithMetadata(product, state, context) {
       try {
         const { filesLib } = context.aioLibs;
         const productUrl = getProductUrl({ urlKey, sku }, context, false).toLowerCase();
-        const htmlPath = `/public/pdps${productUrl}`;
+        const htmlPath = `/public/pdps${productUrl}.${PDP_FILE_EXT}`;
         await filesLib.write(htmlPath, productHtml);
         logger.debug(`Saved HTML for product ${sku} to ${htmlPath}`);
       } catch (e) {

--- a/actions/fetch-all-products/index.js
+++ b/actions/fetch-all-products/index.js
@@ -14,7 +14,7 @@ governing permissions and limitations under the License.
 
 const { CategoriesQuery, ProductCountQuery, ProductsQuery } = require('../queries');
 const { Core, Files } = require('@adobe/aio-sdk')
-const { requestSaaS, FILE_PREFIX, FILE_EXT } = require('../utils');
+const { requestSaaS, FILE_PREFIX, STATE_FILE_EXT } = require('../utils');
 const { Timings } = require('../lib/benchmark');
 
 async function getSkus(categoryPath, context) {
@@ -127,7 +127,7 @@ async function main(params) {
     timings.sample('getAllSkus');
     const filesLib = await Files.init(params.libInit || {});
     timings.sample('saveFile');
-    const productsFileName = `${FILE_PREFIX}/${stateFilePrefix}-products.${FILE_EXT}`;
+    const productsFileName = `${FILE_PREFIX}/${stateFilePrefix}-products.${STATE_FILE_EXT}`;
     await filesLib.write(productsFileName, JSON.stringify(allSkus));
     return timings.measures;
   }));

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 /* This file exposes some common utilities for your actions */
 
 const FILE_PREFIX = 'check-product-changes';
-const FILE_EXT = 'csv';
+const [STATE_FILE_EXT, PDP_FILE_EXT] = ['csv', 'html'];
 
 /**
  *
@@ -380,5 +380,6 @@ module.exports = {
   getProductUrl,
   mapLocale,
   FILE_PREFIX,
-  FILE_EXT,
+  PDP_FILE_EXT,
+  STATE_FILE_EXT,
 }

--- a/e2e/pdp-ssg.e2e.test.js
+++ b/e2e/pdp-ssg.e2e.test.js
@@ -21,7 +21,7 @@ const runtimePackage = 'aem-commerce-ssg'
 const actionUrl = `https://${namespace}.${hostname}/api/v1/web/${runtimePackage}/pdp-renderer`
 
 test('simple product markup', async () => {
-  const res = await fetch(`${actionUrl}/products/crown-summit-backpack/24-mb03`);
+  const res = await fetch(`${actionUrl}/products-ssg/crown-summit-backpack/24-mb03`);
   const content = await res.text();
 
   // Parse markup and compare
@@ -65,12 +65,12 @@ test('simple product markup', async () => {
     "name": "Crown Summit Backpack",
     "gtin": "",
     "description": "The Crown Summit Backpack is equally at home in a gym locker, study cube or a pup tent, so be sure yours is packed with books, a bag lunch, water bottles, yoga block, laptop, or whatever else you want in hand. Rugged enough for day hikes and camping trips, it has two large zippered compartments and padded, adjustable shoulder straps.Top handle.Grommet holes.Two-way zippers.H 20\" x W 14\" x D 12\".Weight: 2 lbs, 8 oz. Volume: 29 L.",
-    "@id": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/crown-summit-backpack/24-MB03",
+    "@id": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/crown-summit-backpack/24-MB03",
     "offers": [
       {
         "@type": "Offer",
         "sku": "24-MB03",
-        "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/crown-summit-backpack/24-MB03",
+        "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/crown-summit-backpack/24-MB03",
         "availability": "https://schema.org/InStock",
         "price": 38,
         "priceCurrency": "USD",
@@ -83,7 +83,7 @@ test('simple product markup', async () => {
 });
 
 test('complex product markup', async () => {
-  const res = await fetch(`${actionUrl}/products/hollister-backyard-sweatshirt/mh05`);
+  const res = await fetch(`${actionUrl}/products-ssg/hollister-backyard-sweatshirt/mh05`);
   const content = await res.text();
 
   // Parse markup and compare
@@ -93,7 +93,7 @@ test('complex product markup', async () => {
   expect($('h1').text()).toEqual('Hollister Backyard Sweatshirt');
 
   // Validate price
-  expect($('.product-details > div > div:contains("Price")').next().text()).toEqual('$2.00-$52.00');
+  expect($('.product-details > div > div:contains("Price")').next().text()).toEqual('$52.00');
 
   // Validate images
   expect($('.product-details > div > div:contains("Images")').next().find('a').map((_, e) => $(e).prop('outerHTML')).toArray()).toMatchInlineSnapshot(`
@@ -149,7 +149,7 @@ test('complex product markup', async () => {
       "https://schema.org/color"
     ],
     "description": "Kick off your weekend in the Hollister Backyard Sweatshirt. Whether you're raking leaves or flipping burgers, this comfy layer blocks the bite of the crisp autumn air. Puffy thick from hood to hem, it traps heat against your core.&bull; Cream crewneck sweatshirt with navy sleeves/trim.&bull; Relaxed fit. &bull; Ribbed cuffs and hem. &bull; Machine wash/dry.",
-    "@id": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05",
+    "@id": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05",
     "hasVariant": [
       {
         "@type": "Product",
@@ -161,7 +161,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-L-Green",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzI%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzI%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -181,7 +181,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-L-Red",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzI%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzI%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -201,7 +201,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-L-White",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzI%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzI%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -221,7 +221,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-M-Green",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81Mjk%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81Mjk%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -241,7 +241,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-M-Red",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81Mjk%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81Mjk%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -261,7 +261,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-M-White",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81Mjk%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81Mjk%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -281,7 +281,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-S-Green",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjY%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjY%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -301,7 +301,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-S-Red",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjY%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjY%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -321,7 +321,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-S-White",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjY%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjY%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -341,7 +341,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-XL-Green",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzU%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzU%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -361,7 +361,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-XL-Red",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzU%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzU%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -381,7 +381,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-XL-White",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzU%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81MzU%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -401,7 +401,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-XS-Green",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjM%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xODQ%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjM%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -421,7 +421,7 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-XS-Red",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjM%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8xOTk%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjM%3D",
             "availability": "https://schema.org/InStock",
             "price": 52,
             "priceCurrency": "USD",
@@ -441,9 +441,9 @@ test('complex product markup', async () => {
           {
             "@type": "Offer",
             "sku": "MH05-XS-White",
-            "url": "https://main--aem-commerce-ssg-storefront--adobe-rnd.aem.live/products/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjM%3D",
+            "url": "https://main--aem-boilerplate-commerce-staging--hlxsites.aem.live/products-ssg/hollister-backyard-sweatshirt/MH05?optionsUIDs=Y29uZmlndXJhYmxlLzI3Ny8yMDI%3D%2CY29uZmlndXJhYmxlLzU1Ni81MjM%3D",
             "availability": "https://schema.org/InStock",
-            "price": 2,
+            "price": 52,
             "priceCurrency": "USD",
             "itemCondition": "https://schema.org/NewCondition"
           }

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -14,7 +14,7 @@ const assert = require('node:assert/strict');
 const { loadState, saveState, getStateFileLocation, poll } = require('../actions/check-product-changes/poller');
 const Files = require('./__mocks__/files');
 const { AdminAPI } = require('../actions/lib/aem');
-const { requestSaaS, requestSpreadsheet, isValidUrl} = require('../actions/utils');
+const { requestSaaS, requestSpreadsheet, isValidUrl } = require('../actions/utils');
 const { MockState } = require('./__mocks__/state');
 
 const EXAMPLE_STATE = 'sku1,1,\nsku2,2,\nsku3,3,';
@@ -43,6 +43,9 @@ jest.mock('../actions/utils', () => ({
   isValidUrl: jest.fn(() => true),
   getProductUrl: jest.fn(({ urlKey, sku }) => `/${urlKey || sku}`),
   mapLocale: jest.fn((locale) => ({ locale })),
+  FILE_PREFIX: 'check-product-changes',
+  STATE_FILE_EXT: 'csv',
+  PDP_FILE_EXT: 'html',
 }));
 
 jest.spyOn(AdminAPI.prototype, 'startProcessing').mockImplementation(jest.fn());
@@ -288,7 +291,7 @@ describe('Poller', () => {
 
       // Verify HTML file was saved
       expect(filesLib.write).toHaveBeenCalledWith(
-        '/public/pdps/url-sku-123',
+        '/public/pdps/url-sku-123.html',
         '<html>Product 123</html>'
       );
 


### PR DESCRIPTION
-fixed e2e tests according to the new product dataset in prod (this is where the CS data comes from)
-added .html extension to let aio-files recognize and serve the output markup with mime type text/html
-had to wait for a complete Complex Product to be ready in the dataset - this is a dependency for e2e tests