### PR TITLE
fix: publish exception propagation

### DIFF
--- a/actions/lib/aem.js
+++ b/actions/lib/aem.js
@@ -224,9 +224,18 @@ class AdminAPI {
         this.trackInFlight('preview', async (complete) => {
             const { logger } = this.context;
             const { records, locale, batchNumber } = batch;
+            const paths = records.map(record => record.path);
+
+            if (paths.length === 0) {
+                logger.info(`Skipping preview for batch id=${batchNumber} for locale=${locale}: no paths to process.`);
+                batch.resolve({ records, locale, batchNumber });
+                complete();
+                return;
+            }
+
             const body = {
                 forceUpdate: true,
-                paths: records.map(record => record.path),
+                paths,
                 delete: false
             };
             const start = new Date();


### PR DESCRIPTION
Errors (even errored http calls) in soBatchPublish can cause throwing unhandled exceptions, leading to app crash.
In the proposed changes they are handled gracefullly.