### PR TITLE
chore: validate html descriptions, warn if invalid

### DIFF
--- a/actions/lib/validateHtml.js
+++ b/actions/lib/validateHtml.js
@@ -1,0 +1,77 @@
+/**
+ * Validates HTML syntax by checking for balanced opening and closing tags
+ * @param {string} html - The HTML string to validate
+ * @returns {Object} - { valid: boolean, reason: string }
+ */
+function validateHtml(html) {
+  if (typeof html !== 'string') {
+    return { valid: false, reason: 'Input must be a string' };
+  }
+
+  if (html.trim() === '') {
+    return { valid: true, reason: 'Empty string is valid' };
+  }
+
+  const stack = [];
+  const selfClosingTags = new Set([
+    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+    'link', 'meta', 'param', 'source', 'track', 'wbr'
+  ]);
+
+  // Regular expression to match HTML tags
+  const tagRegex = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g;
+  let match;
+  let lineNumber = 1;
+  let charPosition = 0;
+
+  while ((match = tagRegex.exec(html)) !== null) {
+    const fullTag = match[0];
+    const tagName = match[1].toLowerCase();
+    const isClosingTag = fullTag.startsWith('</');
+    const isSelfClosing = fullTag.endsWith('/>') || selfClosingTags.has(tagName);
+
+    // Calculate position for error reporting
+    const beforeMatch = html.substring(0, match.index);
+    lineNumber = beforeMatch.split('\n').length;
+    charPosition = match.index - beforeMatch.lastIndexOf('\n') - 1;
+
+    if (isSelfClosing) {
+      // Self-closing tags don't need to be balanced
+      continue;
+    }
+
+    if (isClosingTag) {
+      // Check if we have a matching opening tag
+      if (stack.length === 0) {
+        return {
+          valid: false,
+          reason: `Unexpected closing tag </${tagName}> at line ${lineNumber}, position ${charPosition}`
+        };
+      }
+
+      const lastOpenTag = stack.pop();
+      if (lastOpenTag !== tagName) {
+        return {
+          valid: false,
+          reason: `Mismatched tags: expected </${lastOpenTag}> but found </${tagName}> at line ${lineNumber}, position ${charPosition}`
+        };
+      }
+    } else {
+      // Opening tag - push onto stack
+      stack.push(tagName);
+    }
+  }
+
+  // Check if any opening tags weren't closed
+  if (stack.length > 0) {
+    const unclosedTags = stack.reverse().join(', ');
+    return {
+      valid: false,
+      reason: `Unclosed tags: ${unclosedTags}`
+    };
+  }
+
+  return { valid: true, reason: 'HTML is valid' };
+}
+
+module.exports = { validateHtml }

--- a/actions/pdp-renderer/render.js
+++ b/actions/pdp-renderer/render.js
@@ -5,10 +5,11 @@ const { findDescription, prepareBaseTemplate, getPrimaryImage, generatePriceStri
 const { generateLdJson } = require('./ldJson');
 const { requestSaaS, getProductUrl } = require('../utils');
 const { ProductQuery, ProductByUrlKeyQuery } = require('../queries');
+const { validateHtml } = require('../lib/validateHtml');
 
 const productTemplateCache = {};
 
-function toTemplateProductData(baseProduct) {
+function toTemplateProductData(baseProduct, context) {
   const templateProductData = { ...baseProduct };
   const primaryImage = getPrimaryImage(baseProduct)?.url;
 
@@ -19,6 +20,20 @@ function toTemplateProductData(baseProduct) {
   templateProductData.metaImage = primaryImage;
   templateProductData.primaryImage = primaryImage;
   templateProductData.metaTitle = baseProduct.metaTitle || baseProduct.name || 'Product Details';
+
+  // For each field which can contain HTML, validate it. If it is invalid, strip the HTML and log a warning.
+  const htmlFieldValidations = {
+    metaDescription: validateHtml(templateProductData.metaDescription),
+    shortDescription: validateHtml(templateProductData.shortDescription),
+    description: validateHtml(templateProductData.description)
+  }
+
+  Object.entries(htmlFieldValidations).forEach(([field, validation]) => {
+    if (!validation.valid) {
+      templateProductData[field] = '';
+      context.logger.warn(`HTML validation failed for "${field}" field: ${validation.reason}`);
+    }
+  })
 
   return templateProductData;
 }
@@ -65,7 +80,7 @@ async function generateProductHtml(sku, urlKey, context) {
   }
 
   // Assign meta tag data for template
-  const templateProductData = toTemplateProductData(baseProduct);
+  const templateProductData = toTemplateProductData(baseProduct, context);
 
   // Generate LD-JSON
   const ldJson = await generateLdJson(baseProduct, context);

--- a/actions/pdp-renderer/render.js
+++ b/actions/pdp-renderer/render.js
@@ -21,17 +21,15 @@ function toTemplateProductData(baseProduct, context) {
   templateProductData.primaryImage = primaryImage;
   templateProductData.metaTitle = baseProduct.metaTitle || baseProduct.name || 'Product Details';
 
-  // For each field which can contain HTML, validate it. If it is invalid, strip the HTML and log a warning.
-  const htmlFieldValidations = {
+  const fieldValidations = {
     metaDescription: validateHtml(templateProductData.metaDescription),
     shortDescription: validateHtml(templateProductData.shortDescription),
     description: validateHtml(templateProductData.description)
   }
 
-  Object.entries(htmlFieldValidations).forEach(([field, validation]) => {
+  Object.entries(fieldValidations).forEach(([field, validation]) => {
     if (!validation.valid) {
-      templateProductData[field] = '';
-      context.logger.warn(`HTML validation failed for "${field}" field: ${validation.reason}`);
+      context.logger.warn(`Validation failed for "${field}" field: ${validation.reason}`);
     }
   })
 

--- a/actions/pdp-renderer/render.js
+++ b/actions/pdp-renderer/render.js
@@ -22,7 +22,6 @@ function toTemplateProductData(baseProduct, context) {
   templateProductData.metaTitle = baseProduct.metaTitle || baseProduct.name || 'Product Details';
 
   const fieldValidations = {
-    metaDescription: validateHtml(templateProductData.metaDescription),
     shortDescription: validateHtml(templateProductData.shortDescription),
     description: validateHtml(templateProductData.description)
   }

--- a/actions/queries.js
+++ b/actions/queries.js
@@ -161,7 +161,7 @@ const CategoriesQuery = `
           name
           level
           urlPath
-      }      
+      }
     }
 `;
 
@@ -194,7 +194,7 @@ const ProductsQuery = `
       items {
         productView {
           urlKey
-          sku          
+          sku
         }
       }
       page_info {

--- a/test/mock-responses/mock-product.json
+++ b/test/mock-responses/mock-product.json
@@ -7,7 +7,7 @@
                 "sku": "24-MB03",
                 "name": "Crown Summit Backpack",
                 "url": "http://www.aemshop.net/crown-summit-backpack.html",
-                "description": "<p>The Crown Summit Backpack is equally at home in a gym locker, study cube or a pup tent, so be sure yours is packed with books, a bag lunch, water bottles, yoga block, laptop, or whatever else you want in hand. Rugged enough for day hikes and camping trips, it has two large zippered compartments and padded, adjustable shoulder straps.</p>\r\n<ul>\r\n<li>Top handle.</li>\r\n<li>Grommet holes.</li>\r\n<li>Two-way zippers.</li>\r\n<li>H 20\" x W 14\" x D 12\".</li>\r\n<li>Weight: 2 lbs, 8 oz. Volume: 29 L.</li>\r\n<ul>",
+                "description": "<p>The Crown Summit Backpack is equally at home in a gym locker, study cube or a pup tent, so be sure yours is packed with books, a bag lunch, water bottles, yoga block, laptop, or whatever else you want in hand. Rugged enough for day hikes and camping trips, it has two large zippered compartments and padded, adjustable shoulder straps.</p>\r\n<ul>\r\n<li>Top handle.</li>\r\n<li>Grommet holes.</li>\r\n<li>Two-way zippers.</li>\r\n<li>H 20\" x W 14\" x D 12\".</li>\r\n<li>Weight: 2 lbs, 8 oz. Volume: 29 L.</li>\r\n</ul>",
                 "shortDescription": "",
                 "metaDescription": "",
                 "metaKeyword": "backpack, hiking, camping",

--- a/test/mock-server.js
+++ b/test/mock-server.js
@@ -26,6 +26,33 @@ const handlers = {
     matcher?.(req);
     return HttpResponse.json(mockProduct);
   }),
+
+  defaultProductInvalidShortDescription: (matcher) => graphql.query('ProductQuery', (req) => {
+    matcher?.(req);
+    // Create a product with invalid HTML in shortDescription
+    const invalidProduct = {
+      ...mockProduct.data.products[0],
+      shortDescription: '<div><p>Mismatched tags</div>'
+    };
+    return HttpResponse.json({
+      data: {
+        products: [invalidProduct]
+      }
+    });
+  }),
+  defaultProductInvalidDescription: (matcher) => graphql.query('ProductQuery', (req) => {
+    matcher?.(req);
+    // Create a product with invalid HTML in description
+    const invalidProduct = {
+      ...mockProduct.data.products[0],
+      description: '<ul><li>List item<li>Another item</ul>'
+    };
+    return HttpResponse.json({
+      data: {
+        products: [invalidProduct]
+      }
+    });
+  }),
   defaultComplexProduct: (matcher) => graphql.query('ProductQuery', (req) => {
     matcher?.(req);
     return HttpResponse.json(mockComplexProduct);
@@ -37,6 +64,51 @@ const handlers = {
   defaultProductLiveSearch: (matcher) => graphql.query('ProductByUrlKey', (req) => {
     matcher?.(req);
     return HttpResponse.json(mockProductLs);
+  }),
+  defaultProductBadData: (matcher) => graphql.query('ProductQuery', (req) => {
+    matcher?.(req);
+    // Create a product with invalid HTML in multiple fields
+    const badProduct = {
+      ...mockProduct.data.products[0],
+      metaDescription: '<span>Unclosed span',
+      shortDescription: '<div>Unclosed div',
+      description: '<p>Unclosed paragraph'
+    };
+    return HttpResponse.json({
+      data: {
+        products: [badProduct]
+      }
+    });
+  }),
+  defaultProductValidHtml: (matcher) => graphql.query('ProductQuery', (req) => {
+    matcher?.(req);
+    // Create a product with valid HTML in all fields
+    const validProduct = {
+      ...mockProduct.data.products[0],
+      metaDescription: '<p>Valid paragraph</p>',
+      shortDescription: '<div>Valid div</div>',
+      description: '<ul><li>Valid list item</li></ul>'
+    };
+    return HttpResponse.json({
+      data: {
+        products: [validProduct]
+      }
+    });
+  }),
+  defaultProductEmptyHtml: (matcher) => graphql.query('ProductQuery', (req) => {
+    matcher?.(req);
+    // Create a product with empty/undefined HTML fields
+    const emptyProduct = {
+      ...mockProduct.data.products[0],
+      metaDescription: '',
+      shortDescription: undefined,
+      description: null
+    };
+    return HttpResponse.json({
+      data: {
+        products: [emptyProduct]
+      }
+    });
   }),
   return404: (matcher) => graphql.query('ProductQuery', (req) => {
     matcher?.(req);

--- a/test/pdp-renderer.test.js
+++ b/test/pdp-renderer.test.js
@@ -23,7 +23,7 @@ jest.mock('@adobe/aio-sdk', () => ({
 
 
 const { Core } = require('@adobe/aio-sdk')
-const mockLoggerInstance = { info: jest.fn(), debug: jest.fn(), error: jest.fn() }
+const mockLoggerInstance = { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() }
 Core.Logger.mockReturnValue(mockLoggerInstance)
 
 const action = require('./../actions/pdp-renderer/index.js')
@@ -36,6 +36,7 @@ beforeEach(() => {
   mockLoggerInstance.info.mockReset()
   mockLoggerInstance.debug.mockReset()
   mockLoggerInstance.error.mockReset()
+  mockLoggerInstance.warn.mockReset()
 })
 
 const fakeParams = {
@@ -84,7 +85,7 @@ describe('pdp-renderer', () => {
 
       expect(response.body).toBeDefined();
       expect(typeof response.body).toBe('string');
-      
+
       const $ = cheerio.load(response.body);
       expect($('.product-recommendations')).toHaveLength(1);
       expect($('body > main > div')).toHaveLength(2);
@@ -161,7 +162,7 @@ describe('pdp-renderer', () => {
         PRODUCT_PAGE_URL_FORMAT: '/{urlKey}',
         __ow_path: `/crown-summit-backpack`,
       });
-     
+
       const $ = cheerio.load(response.body);
       expect($('body > main > div.product-details > div > div > h1').text()).toEqual('Crown Summit Backpack');
     });
@@ -243,9 +244,9 @@ describe('pdp-renderer', () => {
 
     test('render images', async () => {
       const response = await getProductResponse();
-      
+
       const $ = cheerio.load(response.body);
-      
+
       expect($('body > main > div.product-details > div > div:contains("Images")').next().find('img').map((_,e) => $(e).prop('outerHTML')).toArray()).toEqual([
         '<img src="http://www.aemshop.net/media/catalog/product/m/b/mb03-black-0.jpg">',
         '<img src="http://www.aemshop.net/media/catalog/product/m/b/mb03-black-0_alt1.jpg">'
@@ -254,9 +255,9 @@ describe('pdp-renderer', () => {
 
     test('render description', async () => {
       const response = await getProductResponse();
-      
+
       const $ = cheerio.load(response.body);
-      
+
       expect($('body > main > div.product-details > div > div:contains("Description")').next().html().trim()).toMatchInlineSnapshot(`
 "<p>The Crown Summit Backpack is equally at home in a gym locker, study cube or a pup tent, so be sure yours is packed with books, a bag lunch, water bottles, yoga block, laptop, or whatever else you want in hand. Rugged enough for day hikes and camping trips, it has two large zippered compartments and padded, adjustable shoulder straps.</p>
     <ul>
@@ -265,24 +266,24 @@ describe('pdp-renderer', () => {
     <li>Two-way zippers.</li>
     <li>H 20" x W 14" x D 12".</li>
     <li>Weight: 2 lbs, 8 oz. Volume: 29 L.</li>
-    <ul></ul></ul>"
+    </ul>"
 `);
     });
 
     test('render price', async () => {
       const response = await getProductResponse();
-      
+
       const $ = cheerio.load(response.body);
 
-      
+
       expect($('body > main > div.product-details > div > div:contains("Price")').next().text()).toBe('$38.00');
     });
 
     test('render title', async () => {
       const response = await getProductResponse();
-      
+
       const $ = cheerio.load(response.body);
-      
+
       expect($('body > main > div.product-details > div > div > h1').text()).toEqual('Crown Summit Backpack');
     });
   })
@@ -428,9 +429,9 @@ describe('generateProductHtml', () => {
   const mockConfig = require('./mock-responses/mock-config.json');
   const server = useMockServer();
   const defaultContext = {
-    logger: { debug: jest.fn() },
+    logger: { debug: jest.fn(), warn: jest.fn() },
     storeUrl: 'https://store.com',
-    contentUrl: 'https://content.com', 
+    contentUrl: 'https://content.com',
     configName: 'config',
   };
 
@@ -455,17 +456,17 @@ describe('generateProductHtml', () => {
       // Use both handlers for 404 responses
       server.use(handlers.return404());
       server.use(handlers.returnLiveSearch404());
-      
+
       // Mock the config to be pre-loaded to avoid the HTTP request
       const contextWithConfig = {
         ...defaultContext,
         config: mockConfig.data.reduce((acc, { key, value }) => ({ ...acc, [key]: value }), {})
       };
-      
+
       await expect(generateProductHtml('NON-EXISTENT', null, contextWithConfig))
         .rejects
         .toThrow('Product not found');
-        
+
       await expect(generateProductHtml(null, 'non-existent-product', contextWithConfig))
         .rejects
         .toThrow('Product not found');
@@ -475,7 +476,7 @@ describe('generateProductHtml', () => {
   describe('HTML generation', () => {
     test('generates HTML with product template', async () => {
       server.use(handlers.defaultProduct());
-      
+
       // Mock the template fetch
       const templateHtml = fs.readFileSync(path.join(__dirname, 'mock-responses', 'product-default.html'), 'utf8');
       server.use(

--- a/test/validateHtml.test.js
+++ b/test/validateHtml.test.js
@@ -1,0 +1,320 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE/2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under this License.
+*/
+
+const { validateHtml } = require('../actions/lib/validateHtml');
+
+describe('validateHtml', () => {
+  describe('input validation', () => {
+    test('should return error for non-string input', () => {
+      expect(validateHtml(null)).toEqual({
+        valid: false,
+        reason: 'Input must be a string'
+      });
+
+      expect(validateHtml(undefined)).toEqual({
+        valid: false,
+        reason: 'Input must be a string'
+      });
+
+      expect(validateHtml(123)).toEqual({
+        valid: false,
+        reason: 'Input must be a string'
+      });
+
+      expect(validateHtml({})).toEqual({
+        valid: false,
+        reason: 'Input must be a string'
+      });
+    });
+
+    test('should return valid for empty string', () => {
+      expect(validateHtml('')).toEqual({
+        valid: true,
+        reason: 'Empty string is valid'
+      });
+
+      expect(validateHtml('   ')).toEqual({
+        valid: true,
+        reason: 'Empty string is valid'
+      });
+    });
+  });
+
+  describe('valid HTML', () => {
+    test('should validate simple HTML', () => {
+      expect(validateHtml('<p>Hello World</p>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should validate nested HTML', () => {
+      expect(validateHtml('<div><p>Hello <strong>World</strong></p></div>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should validate complex nested HTML', () => {
+      const complexHtml = `
+        <html>
+          <head>
+            <title>Test Page</title>
+          </head>
+          <body>
+            <div class="container">
+              <header>
+                <h1>Main Title</h1>
+                <nav>
+                  <ul>
+                    <li><a href="/">Home</a></li>
+                    <li><a href="/about">About</a></li>
+                  </ul>
+                </nav>
+              </header>
+              <main>
+                <article>
+                  <h2>Article Title</h2>
+                  <p>Article content with <em>emphasis</em> and <strong>strong text</strong>.</p>
+                </article>
+              </main>
+            </div>
+          </body>
+        </html>
+      `;
+
+      expect(validateHtml(complexHtml)).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should validate HTML with attributes', () => {
+      expect(validateHtml('<div class="test" id="main" data-value="123">Content</div>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+  });
+
+  describe('self-closing tags', () => {
+    test('should validate self-closing tags', () => {
+      expect(validateHtml('<img src="image.jpg" alt="Image" />')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+
+      expect(validateHtml('<br/>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+
+      expect(validateHtml('<input type="text" />')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should validate HTML with mixed self-closing and regular tags', () => {
+      expect(validateHtml('<div><img src="img.jpg" /><p>Text</p></div>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should validate all self-closing tag types', () => {
+      const selfClosingTags = [
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+        'link', 'meta', 'param', 'source', 'track', 'wbr'
+      ];
+
+      selfClosingTags.forEach(tag => {
+        expect(validateHtml(`<${tag} />`)).toEqual({
+          valid: true,
+          reason: 'HTML is valid'
+        });
+      });
+    });
+  });
+
+  describe('invalid HTML', () => {
+    test('should detect unclosed tags', () => {
+      expect(validateHtml('<div>Content')).toEqual({
+        valid: false,
+        reason: 'Unclosed tags: div'
+      });
+
+      expect(validateHtml('<div><p>Content')).toEqual({
+        valid: false,
+        reason: 'Unclosed tags: p, div'
+      });
+    });
+
+        test('should detect mismatched tags', () => {
+      expect(validateHtml('<div>Content</p>')).toEqual({
+        valid: false,
+        reason: 'Mismatched tags: expected </div> but found </p> at line 1, position 12'
+      });
+
+      expect(validateHtml('<div><p>Content</div></p>')).toEqual({
+        valid: false,
+        reason: 'Mismatched tags: expected </p> but found </div> at line 1, position 15'
+      });
+    });
+
+        test('should detect unexpected closing tags', () => {
+      expect(validateHtml('</div>')).toEqual({
+        valid: false,
+        reason: 'Unexpected closing tag </div> at line 1, position 0'
+      });
+
+      expect(validateHtml('Content</p>')).toEqual({
+        valid: false,
+        reason: 'Unexpected closing tag </p> at line 1, position 7'
+      });
+    });
+
+    test('should detect complex mismatched structure', () => {
+      const invalidHtml = `
+        <div>
+          <header>
+            <h1>Title</h1>
+          </div>
+          <main>
+            <p>Content</p>
+          </header>
+        </main>
+      `;
+
+      expect(validateHtml(invalidHtml)).toEqual({
+        valid: false,
+        reason: 'Mismatched tags: expected </header> but found </div> at line 5, position 10'
+      });
+    });
+  });
+
+  describe('line and position reporting', () => {
+    test('should report correct line numbers for single line', () => {
+      expect(validateHtml('<div>Content</p>')).toEqual({
+        valid: false,
+        reason: 'Mismatched tags: expected </div> but found </p> at line 1, position 12'
+      });
+    });
+
+    test('should report correct line numbers for multi-line', () => {
+      const multiLineHtml = `
+        <div>
+          <p>First paragraph</p>
+          <p>Second paragraph</p>
+        </div>
+        <p>Unclosed paragraph
+      `;
+
+      expect(validateHtml(multiLineHtml)).toEqual({
+        valid: false,
+        reason: 'Unclosed tags: p'
+      });
+    });
+
+    test('should report correct position within line', () => {
+      expect(validateHtml('  <div>Content</span>')).toEqual({
+        valid: false,
+        reason: 'Mismatched tags: expected </div> but found </span> at line 1, position 14'
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should handle HTML with comments', () => {
+      expect(validateHtml('<div><!-- Comment -->Content</div>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should handle HTML with DOCTYPE', () => {
+      expect(validateHtml('<!DOCTYPE html><html><body>Content</body></html>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should handle HTML with script tags', () => {
+      expect(validateHtml('<div><script>console.log("test");</script></div>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should handle HTML with style tags', () => {
+      expect(validateHtml('<div><style>.test { color: red; }</style></div>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should handle HTML with special characters in attributes', () => {
+      expect(validateHtml('<div data-test="value with \'quotes\' and double quotes">Content</div>')).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    test('should validate product description HTML', () => {
+      const productDescription = `
+        <div class="product-description">
+          <h3>Product Features</h3>
+          <ul>
+            <li>High quality material</li>
+            <li>Comfortable fit</li>
+            <li>Available in multiple colors</li>
+          </ul>
+          <p>This product is made with <strong>premium materials</strong> and designed for <em>maximum comfort</em>.</p>
+        </div>
+      `;
+
+      expect(validateHtml(productDescription)).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should validate meta description with HTML', () => {
+      const metaDescription = 'Product description with <strong>bold text</strong> and <em>italic emphasis</em>.';
+
+      expect(validateHtml(metaDescription)).toEqual({
+        valid: true,
+        reason: 'HTML is valid'
+      });
+    });
+
+    test('should detect issues in product description', () => {
+      const invalidDescription = `
+        <div class="product-info">
+          <h3>Product Details</h3>
+          <p>Product description here
+          <ul>
+            <li>Feature 1</li>
+            <li>Feature 2</li>
+          </div>
+        </ul>
+      `;
+
+      expect(validateHtml(invalidDescription)).toEqual({
+        valid: false,
+        reason: 'Mismatched tags: expected </ul> but found </div> at line 8, position 10'
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #194 

The reason this is happening is due to incorrect format in description data.

Technically this might happen for _any_ user defined string which can be HTML.

This PR validates html for fields we are trying to template in that might be invalid.

DEBATE:

* What do we do if the field is invalid? (log)
* Do we check all "variables" being injected? (just shortDescription, description for now)
