### PR TITLE
fix: batch requests to get last modified dates

### DIFF
--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -142,7 +142,7 @@ describe('Poller', () => {
   };
 
   const mockSaaSResponse = (skus, lastModifiedOffset = 10000) => {
-    requestSaaS.mockImplementation((query, operation) => {
+    requestSaaS.mockImplementation((query, operation, variables) => {
       if (operation === 'getAllSkus') {
         return Promise.resolve({
           data: {
@@ -155,7 +155,7 @@ describe('Poller', () => {
       if (operation === 'getLastModified') {
         return Promise.resolve({
           data: {
-            products: skus.map(sku => ({ 
+            products: variables.skus.map(sku => ({ 
               urlKey: `url-${sku}`, 
               sku, 
               lastModifiedAt: new Date().getTime() - lastModifiedOffset 
@@ -314,6 +314,35 @@ describe('Poller', () => {
           null,
           1
       );
+      expect(AdminAPI.prototype.startProcessing).toHaveBeenCalledTimes(1);
+      expect(AdminAPI.prototype.stopProcessing).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle large number of products in batches', async () => {
+      const now = new Date().getTime();
+      const filesLib = mockFiles();
+      const stateLib = mockState();
+      const skus = Array.from({ length: 10000 }, (_, i) => `sku-${i}`);
+      const skuData = skus.reduce((acc, sku) => {
+        acc[sku] = { timestamp: now - 100000 };
+        return acc;
+      }, {});
+
+      // Setup initial state with existing products
+      setupSkuData(filesLib, stateLib, skuData, now - 700000);
+      // Mock catalog service responses
+      mockSaaSResponse(skus, 5000);
+
+      const result = await poll(defaultParams, { filesLib, stateLib }, mockLogger);
+
+      // Verify results
+      expect(result.state).toBe('completed');
+      expect(result.status.published).toBe(skus.length);
+      expect(result.status.ignored).toBe(0);
+
+      // Verify API calls (batch size is 50)
+      expect(requestSaaS).toHaveBeenCalledTimes(skus.length / 50);
+      expect(AdminAPI.prototype.previewAndPublish).toHaveBeenCalledTimes(skus.length / 50);
       expect(AdminAPI.prototype.startProcessing).toHaveBeenCalledTimes(1);
       expect(AdminAPI.prototype.stopProcessing).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
As reported by the Catalog Service team, requesting a large set of last modified dates for many skus at once is a problem.
We do that as part of the change detection today to detect if we have to re-render a specific skus PDP.

Currently we request the last modified date for all known skus at once. This is limiting the total amount of PDPs, but also putting pressure on Catalog Service. 

We should batch this with a defined max concurrency:
- batches of 50 SKUs at once
- 50 requests concurrently max