### PR TITLE
SITES-34681: Health check fails during prerenderer installation via UI

### DIFF
--- a/bin/setup/ui/setup-wizard.js
+++ b/bin/setup/ui/setup-wizard.js
@@ -1197,31 +1197,6 @@ export class SetupWizard extends LitElement {
     async performHealthChecks() {
         this.loading = true;
         this.healthChecks = [];
-
-        // Health check for local files endpoint
-        try {
-            const filesUrl = `${window.location.origin}/api/files`;
-            const filesResponse = await fetch(filesUrl, {
-                headers: {
-                    'x-aio-auth': this.aioAuth,
-                    'x-aio-namespace': this.aioNamespace
-                }
-            });
-
-            // We expect a 2xx status code for success
-            this.healthChecks.push({
-                name: 'Files Endpoint',
-                status: filesResponse.status >= 200 && filesResponse.status < 300,
-                message: filesResponse.status >= 200 && filesResponse.status < 300 ? 'Files endpoint accessible' : 'Files endpoint not accessible'
-            });
-        } catch (error) {
-            this.healthChecks.push({
-                name: 'Files Endpoint',
-                status: false,
-                message: 'Failed to check files endpoint'
-            });
-        }
-
         // Health check for rules endpoint
         try {
             const rulesUrl = `${window.location.origin}/api/rules`;


### PR DESCRIPTION
Since file system access through @adobe/aio is only available when connected to the Adobe VPN, I removed the lines that attempted to check the file system for clients. On their local machines this logic would not work and could cause errors, so it has been removed to ensure compatibility outside of the VPN environment.