### PR TITLE
[SITES-38376] check product change fix

### DIFF
--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -309,7 +309,7 @@ async function processDeletedProducts(remainingSkus, state, context, adminApi) {
               if (record.liveUnpublishedAt && record.previewUnpublishedAt) {
                 // Delete the HTML file from public storage
                 try {
-                  const htmlPath = `/public/pdps${record.path}`;
+                  const htmlPath = `/public/pdps${record.path}.${PDP_FILE_EXT}`;
                   filesLib.delete(htmlPath);
                   logger.debug(`Deleted HTML file for product ${record.sku} from ${htmlPath}`);
                 } catch (e) {

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -587,8 +587,8 @@ describe('Poller', () => {
 
       // Verify HTML files were deleted
       expect(filesLib.delete).toHaveBeenCalledTimes(2);
-      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/p/url-sku-123');
-      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/p/url-sku-456');
+      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/p/url-sku-123.html');
+      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/p/url-sku-456.html');
     });
   });
 });


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SITES-38376

fixed an issue where check-product-change was calling fileLib.delete() without the file's extension.