### PR TITLE
fix: commit default e2e/config.json for stage e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 
 # Config
 config.json
+!e2e/config.json
 .env*
 .aio
 

--- a/e2e/config.json
+++ b/e2e/config.json
@@ -1,0 +1,4 @@
+{
+  "pdpSku": "ADB177",
+  "plpSlug": "apparel"
+}


### PR DESCRIPTION
## Summary
- The "Deploy to Stage" workflow has been failing at the `npm run e2e` step on every run since #267 merged (see [run 33022323724](https://github.com/adobe-rnd/aem-commerce-prerender/actions/runs/33022323724/job/98355471448)), with `Cannot find module './config.json'`.
- `e2e/pdp-ssg.e2e.test.js` and `e2e/plp-ssg.e2e.test.js` (added/rewritten in #267) read `pdpSku`/`plpSlug` from `e2e/config.json`, but that path was gitignored and never generated in CI.
- This un-ignores `e2e/config.json` specifically and commits the default demo values already documented in `docs/CUSTOMIZE.md` (`pdpSku: ADB177`, `plpSlug: apparel`).

## Test plan
- [ ] `Build and Test` PR check passes (build/lint/unit tests)
- [ ] After merge, confirm the next `Deploy to Stage` run passes the `npm run e2e` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)